### PR TITLE
Add npm bridge installer and setup guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   verify:
@@ -47,6 +48,8 @@ jobs:
           & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" installer/windows/codex-firefox-bridge.iss
           New-Item dist -ItemType Directory -Force | Out-Null
           Copy-Item installer/windows/Output/*.exe dist/
+          Copy-Item native-host/target/release/codex-firefox-bridge.exe `
+            "dist/codex-firefox-bridge-$version-windows-x64.exe"
       - name: Sign Windows installer
         if: env.WINDOWS_SIGNING_CERTIFICATE_PFX != ''
         shell: pwsh
@@ -101,6 +104,8 @@ jobs:
             native-host/target/aarch64-apple-darwin/release/codex-firefox-bridge \
             native-host/target/x86_64-apple-darwin/release/codex-firefox-bridge \
             -output "$root/Library/Application Support/Codex Firefox Bridge/codex-firefox-bridge"
+          cp "$root/Library/Application Support/Codex Firefox Bridge/codex-firefox-bridge" \
+            "dist/codex-firefox-bridge-$version-macos-universal"
           cp installer/macos/com.openai.codexextension.json \
             "$root/Library/Application Support/Codex Firefox Bridge/"
           cp installer/macos/scripts/postinstall "$scripts/postinstall"
@@ -145,15 +150,36 @@ jobs:
         run: |
           set -euo pipefail
           version="$(node -p "require('./version.json').version")"
-          shasum -a 256 dist/*.pkg > "dist/codex-firefox-bridge-$version-macos-universal.sha256"
+          shasum -a 256 \
+            dist/*.pkg \
+            "dist/codex-firefox-bridge-$version-macos-universal" \
+            > "dist/codex-firefox-bridge-$version-macos-universal.sha256"
       - uses: actions/upload-artifact@v4
         with:
           name: macos-companion
           path: dist/*
 
+  npm-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm test
+        working-directory: npm
+      - name: Pack npm installer
+        run: |
+          mkdir -p dist
+          npm pack ./npm --pack-destination dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-installer
+          path: dist/*.tgz
+
   publish:
     if: github.ref_type == 'tag'
-    needs: [verify, windows-companion, macos-companion]
+    needs: [verify, windows-companion, macos-companion, npm-package]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -164,3 +190,22 @@ jobs:
         with:
           generate_release_notes: true
           files: release/*
+
+  publish-npm:
+    if: github.ref_type == 'tag'
+    needs: publish
+    runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      - name: Publish npm installer with provenance
+        if: env.NODE_AUTH_TOKEN != ''
+        run: npm publish ./npm --access public --provenance
+      - name: Explain skipped npm publish
+        if: env.NODE_AUTH_TOKEN == ''
+        run: echo "::notice::NPM_TOKEN is not configured; the npm package was attached to the GitHub release but not published to npm."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ This project follows semantic versioning. The Firefox add-on and native companio
 always share one version and are released from a matching `vMAJOR.MINOR.PATCH`
 Git tag.
 
+## 1.4.0 - 2026-07-23
+
+- Added `codex-firefox-bridge` as a terminal-friendly npm installer with
+  `install`, `doctor`, and `uninstall` commands.
+- Kept the Windows `.exe` and macOS universal `.pkg` as first-class install
+  choices.
+- Added verified raw companion binaries and an npm tarball to GitHub releases.
+- Added npm provenance publishing support to the release workflow.
+- Added an in-extension npm install option and an explanation of why the local
+  bridge is currently required.
+
 ## 1.3.0 - 2026-07-23
 
 - Replaced the Windows-only development adapter with a cross-platform Rust

--- a/README.md
+++ b/README.md
@@ -44,18 +44,45 @@ See [PORT_STATUS.md](PORT_STATUS.md) for the test evidence and the remaining low
 ## Install
 
 The Firefox add-on and its companion bridge are versioned together. Release
-`1.3.0` adds companion installers for Windows and macOS:
+`1.4.0` provides three supported ways to install the companion:
 
 - Windows: run `codex-firefox-bridge-<version>-windows-x64-setup.exe`. It installs
   per-user and does not require administrator access.
 - macOS: open `codex-firefox-bridge-<version>-macos-universal.pkg`. The universal
   package supports both Apple Silicon and Intel Macs.
+- npm (Windows or macOS):
+
+  ```sh
+  npx --yes codex-firefox-bridge@1.4.0 install
+  ```
+
+  This is a persistent per-user installation, not a bridge that only lives for
+  the duration of `npx`. Inspect it later with
+  `npx --yes codex-firefox-bridge@1.4.0 doctor`, or remove it with the
+  corresponding `uninstall` command.
 
 Install the companion once, then install the matching signed Firefox add-on.
 The bridge discovers the official OpenAI extension host at runtime, so it does
 not retain a repository path or a machine-specific Codex cache path. An existing
 Codex/ChatGPT installation and the official Chrome integration are still
 required.
+
+### Why is the companion required?
+
+Firefox WebExtensions are intentionally sandboxed: they cannot launch an
+arbitrary local program, attach to Codex's private standard-input/output
+transport, or reuse a native-messaging host registered only for a Chrome
+extension ID. Codex currently provides its browser connection through that
+native-host integration rather than a supported Firefox API or authenticated
+local app-server endpoint.
+
+The small companion is therefore the OS-level handoff Firefox requires. It
+registers for this extension, discovers the existing official OpenAI host, and
+translates the Firefox connection to it. It does not replace Codex or provide a
+remote service.
+
+If OpenAI opens an official Firefox path or another supported local connection,
+we'd love to adopt it and simplify or remove this companion :)
 
 ### Local development
 
@@ -105,10 +132,12 @@ surface, then runs native-protocol, upload, and WebSocket-relay integration
 tests. Packaging writes the unsigned extension archive, a matching review-source
 archive generated from the committed tree, and SHA-256 checksums to `dist/`.
 
-Pushing a semantic-version tag such as `v1.3.0` runs the release workflow. It
+Pushing a semantic-version tag such as `v1.4.0` runs the release workflow. It
 builds and tests the extension, a Windows x64 installer, and a universal macOS
-package; verifies that the tag, extension, package, and companion versions
-match; generates checksums; and attaches all artifacts to the GitHub release.
+package; verifies that the tag, extension, npm package, and companion versions
+match; generates checksums; and attaches the installers, raw bridge binaries,
+and npm tarball to the GitHub release. If `NPM_TOKEN` is configured, it also
+publishes the npm package with provenance.
 Prepare the next version with `npm run version:set -- MAJOR.MINOR.PATCH`; this
 updates every version-bearing file together. Production releases should configure
 the signing secrets described in `.github/workflows/release.yml`.

--- a/extension/companion-required.css
+++ b/extension/companion-required.css
@@ -95,6 +95,64 @@ h1 {
   font-size: 0.8rem;
 }
 
+.developer-install,
+.why {
+  margin-top: 1.25rem;
+  padding: 1.1rem;
+  border: 1px solid rgba(23, 23, 23, 0.12);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.45);
+}
+
+.developer-install h2,
+.why h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.developer-install p,
+.why p {
+  margin: 0.5rem 0 0;
+  color: #55504a;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.option-label {
+  color: #9a4f16 !important;
+  font-size: 0.7rem !important;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.command-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.command-row code {
+  min-width: 0;
+  flex: 1;
+  overflow-x: auto;
+  padding: 0.7rem;
+  border-radius: 0.55rem;
+  background: #171717;
+  color: #f7f3ec;
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.command-row button {
+  border: 1px solid rgba(23, 23, 23, 0.2);
+  border-radius: 0.55rem;
+  padding: 0 0.9rem;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
 ol {
   margin: 2rem 0;
   padding-left: 1.25rem;
@@ -138,12 +196,24 @@ ol {
 
   .lede,
   .download span,
+  .developer-install p,
+  .why p,
   .footnote {
     color: #bbb3a8;
   }
 
   .download {
     border-color: rgba(255, 255, 255, 0.15);
+  }
+
+  .developer-install,
+  .why {
+    border-color: rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .command-row button {
+    border-color: rgba(255, 255, 255, 0.2);
   }
 
   .download:hover,

--- a/extension/companion-required.html
+++ b/extension/companion-required.html
@@ -26,11 +26,40 @@
           <span>Universal package · Apple Silicon and Intel</span>
         </a>
       </section>
+      <section class="developer-install" aria-labelledby="developer-install-title">
+        <div>
+          <p class="option-label">Developer path</p>
+          <h2 id="developer-install-title">Install with npm</h2>
+          <p>
+            Prefer a terminal? This installs and registers the same bridge
+            per-user. It remains installed after the command exits.
+          </p>
+        </div>
+        <div class="command-row">
+          <code id="npm-command">npx --yes codex-firefox-bridge@VERSION install</code>
+          <button id="copy-npm-command" type="button">Copy</button>
+        </div>
+      </section>
       <ol>
-        <li>Download and run the companion for this computer.</li>
+        <li>Choose a platform installer or the npm command above.</li>
         <li>Keep the existing Codex Chrome integration installed.</li>
         <li>Close this page and reopen the Codex sidebar.</li>
       </ol>
+      <section class="why" aria-labelledby="why-title">
+        <h2 id="why-title">Why is this needed?</h2>
+        <p>
+          Firefox extensions cannot launch local programs or reuse a native host
+          registered for a Chrome extension. Codex currently exposes its browser
+          connection through that native-host path, not through a supported
+          Firefox API or authenticated local endpoint. The companion crosses
+          that browser/operating-system boundary and translates the connection
+          to the official Codex host.
+        </p>
+        <p>
+          If OpenAI opens an official Firefox route or another supported local
+          connection, we'd love to use it and simplify or remove this companion :)
+        </p>
+      </section>
       <p class="footnote">
         This independent compatibility project is not an official OpenAI or
         Mozilla release. Installer source and checksums are included with every

--- a/extension/companion-required.js
+++ b/extension/companion-required.js
@@ -6,11 +6,27 @@
     `https://github.com/SunkenInTime/codex-computer-use-firefox-zen/releases/download/v${version}`;
   const windows = document.querySelector("#windows-download");
   const macos = document.querySelector("#macos-download");
+  const npmCommand = document.querySelector("#npm-command");
+  const copyNpmCommand = document.querySelector("#copy-npm-command");
+  const command = `npx --yes codex-firefox-bridge@${version} install`;
 
   windows.href =
     `${releaseBase}/codex-firefox-bridge-${version}-windows-x64-setup.exe`;
   macos.href =
     `${releaseBase}/codex-firefox-bridge-${version}-macos-universal.pkg`;
+  npmCommand.textContent = command;
+  copyNpmCommand.addEventListener("click", async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      copyNpmCommand.textContent = "Copied";
+      setTimeout(() => {
+        copyNpmCommand.textContent = "Copy";
+      }, 1600);
+    } catch {
+      window.getSelection()?.selectAllChildren(npmCommand);
+      copyNpmCommand.textContent = "Selected";
+    }
+  });
 
   browser.runtime.getPlatformInfo().then(({ os }) => {
     if (os === "win") {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Codex Computer Use for Zen & Fox",
   "description": "Bring Codex computer use and its signed-in sidebar to Firefox and Zen Browser.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "icons": {
     "16": "images/firefox-zen-icon16.png",
     "32": "images/firefox-zen-icon32.png",

--- a/native-host/Cargo.lock
+++ b/native-host/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "codex-firefox-bridge"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "base64",
  "regex",

--- a/native-host/Cargo.toml
+++ b/native-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-firefox-bridge"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 description = "Firefox native-messaging bridge for the installed OpenAI Codex extension host"
 license = "UNLICENSED"

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,32 @@
+# Codex Firefox Bridge
+
+Install the native-messaging companion used by Codex Computer Use for Firefox
+and Zen Browser:
+
+```sh
+npx --yes codex-firefox-bridge install
+```
+
+The command downloads the matching bridge from the GitHub release, verifies its
+published SHA-256 checksum, installs it in the current user's application-data
+directory, registers it with Firefox, and runs a diagnostic.
+
+```sh
+npx --yes codex-firefox-bridge doctor
+npx --yes codex-firefox-bridge uninstall
+```
+
+This is an independent compatibility project, not an official OpenAI or Mozilla
+package. The official Codex Chrome integration must already be installed because
+the bridge delegates to its local OpenAI host.
+
+## Why is this needed?
+
+Firefox extensions cannot start arbitrary local processes or reuse a native
+host registered for a Chrome extension. Codex currently exposes its browser
+connection through that native-host path, rather than a supported Firefox API
+or authenticated local endpoint, so this bridge provides the required
+per-user OS registration and delegates to the official host.
+
+If OpenAI opens an official Firefox path or another supported local connection,
+we'd love to adopt it and simplify or remove this companion :)

--- a/npm/cli.mjs
+++ b/npm/cli.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  HOST_NAME,
+  assertSafeInstallDirectory,
+  checksumAsset,
+  expectedChecksum,
+  installLocations,
+  nativeManifest,
+  platformAsset,
+  readInstalledManifest,
+  releaseBase
+} from "./lib.mjs";
+
+const packageDirectory = path.dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(packageDirectory, "package.json"), "utf8")
+);
+const version = packageJson.version;
+const command = process.argv[2] ?? "help";
+
+async function download(url) {
+  const response = await fetch(url, {
+    headers: { "user-agent": `codex-firefox-bridge/${version}` },
+    redirect: "follow"
+  });
+  if (!response.ok) {
+    throw new Error(`Download failed (${response.status}): ${url}`);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+function writeManifest(manifestPath, binaryPath) {
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(
+    manifestPath,
+    `${JSON.stringify(nativeManifest(binaryPath), null, 2)}\n`,
+    "utf8"
+  );
+}
+
+function registerWindows(manifestPath, registryKey) {
+  execFileSync(
+    "reg",
+    ["add", registryKey, "/ve", "/t", "REG_SZ", "/d", manifestPath, "/f"],
+    { stdio: "ignore" }
+  );
+}
+
+async function install() {
+  const locations = installLocations();
+  const directory = assertSafeInstallDirectory(locations.directory);
+  const assetName = platformAsset(version);
+  const binaryName =
+    process.platform === "win32"
+      ? `codex-firefox-bridge-${version}.exe`
+      : `codex-firefox-bridge-${version}`;
+  const binaryPath = path.join(directory, binaryName);
+  const suppliedBinary = process.env.CODEX_FIREFOX_BRIDGE_BINARY;
+
+  let binary;
+  if (suppliedBinary) {
+    binary = fs.readFileSync(suppliedBinary);
+  } else {
+    const base = releaseBase(version);
+    const [downloadedBinary, checksums] = await Promise.all([
+      download(`${base}/${assetName}`),
+      download(`${base}/${checksumAsset(version)}`)
+    ]);
+    const expected = expectedChecksum(checksums.toString("utf8"), assetName);
+    const actual = crypto.createHash("sha256").update(downloadedBinary).digest("hex");
+    if (actual !== expected) {
+      throw new Error(`Checksum mismatch for ${assetName}.`);
+    }
+    binary = downloadedBinary;
+  }
+
+  fs.mkdirSync(directory, { recursive: true });
+  const temporaryPath = `${binaryPath}.${process.pid}.tmp`;
+  fs.writeFileSync(temporaryPath, binary, { mode: 0o755 });
+  fs.renameSync(temporaryPath, binaryPath);
+  if (process.platform !== "win32") {
+    fs.chmodSync(binaryPath, 0o755);
+  }
+  writeManifest(locations.manifest, binaryPath);
+  if (process.platform === "win32") {
+    registerWindows(locations.manifest, locations.registryKey);
+  }
+
+  console.log(`Installed Codex Firefox Bridge ${version}`);
+  console.log(`Binary: ${binaryPath}`);
+  console.log(`Manifest: ${locations.manifest}`);
+  doctor();
+}
+
+function doctor() {
+  const locations = installLocations();
+  const manifest = readInstalledManifest(locations.manifest);
+  if (!fs.existsSync(manifest.path)) {
+    throw new Error(`Registered bridge binary is missing: ${manifest.path}`);
+  }
+  if (process.platform === "win32") {
+    const registration = execFileSync(
+      "reg",
+      ["query", locations.registryKey, "/ve"],
+      { encoding: "utf8" }
+    );
+    if (!registration.includes(locations.manifest)) {
+      throw new Error("Firefox native-host registry entry is missing or incorrect.");
+    }
+  }
+  const diagnostic = execFileSync(manifest.path, ["--diagnose"], {
+    encoding: "utf8",
+    timeout: 15_000
+  }).trim();
+  console.log("Registration: OK");
+  console.log(diagnostic);
+}
+
+function uninstall() {
+  const locations = installLocations();
+  const directory = assertSafeInstallDirectory(locations.directory);
+  if (process.platform === "win32") {
+    try {
+      execFileSync("reg", ["delete", locations.registryKey, "/f"], {
+        stdio: "ignore"
+      });
+    } catch {
+      // The registration may already be absent.
+    }
+  }
+  if (fs.existsSync(locations.manifest)) {
+    try {
+      readInstalledManifest(locations.manifest);
+      fs.rmSync(locations.manifest, { force: true });
+    } catch (error) {
+      throw new Error(
+        `Refusing to remove an unfamiliar native-host manifest: ${error.message}`
+      );
+    }
+  }
+  fs.rmSync(directory, { recursive: true, force: true });
+  console.log("Removed Codex Firefox Bridge.");
+}
+
+function help() {
+  console.log(`Codex Firefox Bridge ${version}
+
+Usage:
+  codex-firefox-bridge install
+  codex-firefox-bridge doctor
+  codex-firefox-bridge uninstall
+
+The install command downloads the matching bridge release, verifies its SHA-256
+checksum, installs it per-user, and registers it with Firefox and Zen.`);
+}
+
+try {
+  if (command === "install") {
+    await install();
+  } else if (command === "doctor") {
+    doctor();
+  } else if (command === "uninstall") {
+    uninstall();
+  } else if (command === "--version" || command === "version") {
+    console.log(version);
+  } else if (command === "help" || command === "--help" || command === "-h") {
+    help();
+  } else {
+    throw new Error(`Unknown command: ${command}`);
+  }
+} catch (error) {
+  console.error(`codex-firefox-bridge: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/npm/lib.mjs
+++ b/npm/lib.mjs
@@ -1,0 +1,121 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const HOST_NAME = "com.openai.codexextension";
+export const GECKO_EXTENSION_ID =
+  "codex-computer-use-firefox-zen@sunkenintime";
+export const REPOSITORY =
+  "SunkenInTime/codex-computer-use-firefox-zen";
+
+export function platformAsset(version, platform = process.platform, arch = process.arch) {
+  if (platform === "win32" && arch === "x64") {
+    return `codex-firefox-bridge-${version}-windows-x64.exe`;
+  }
+  if (platform === "darwin" && (arch === "arm64" || arch === "x64")) {
+    return `codex-firefox-bridge-${version}-macos-universal`;
+  }
+  throw new Error(
+    `Unsupported platform: ${platform}/${arch}. Use the platform installer from the GitHub release.`
+  );
+}
+
+export function checksumAsset(version, platform = process.platform) {
+  if (platform === "win32") {
+    return `codex-firefox-bridge-${version}-windows-x64.sha256`;
+  }
+  if (platform === "darwin") {
+    return `codex-firefox-bridge-${version}-macos-universal.sha256`;
+  }
+  throw new Error(`Unsupported platform: ${platform}`);
+}
+
+export function releaseBase(version) {
+  return (
+    process.env.CODEX_FIREFOX_BRIDGE_RELEASE_BASE ??
+    `https://github.com/${REPOSITORY}/releases/download/v${version}`
+  ).replace(/\/$/u, "");
+}
+
+export function installLocations(
+  platform = process.platform,
+  environment = process.env,
+  home = os.homedir()
+) {
+  const platformPath = platform === "win32" ? path.win32 : path.posix;
+  if (platform === "win32") {
+    const localAppData = environment.LOCALAPPDATA;
+    if (!localAppData) {
+      throw new Error("LOCALAPPDATA is unavailable.");
+    }
+    const directory = platformPath.join(localAppData, "Codex Firefox Bridge");
+    return {
+      directory,
+      manifest: platformPath.join(directory, `${HOST_NAME}.json`),
+      registryKey: `HKCU\\Software\\Mozilla\\NativeMessagingHosts\\${HOST_NAME}`
+    };
+  }
+  if (platform === "darwin") {
+    const directory = platformPath.join(
+      home,
+      "Library",
+      "Application Support",
+      "Codex Firefox Bridge"
+    );
+    return {
+      directory,
+      manifest: platformPath.join(
+        home,
+        "Library",
+        "Application Support",
+        "Mozilla",
+        "NativeMessagingHosts",
+        `${HOST_NAME}.json`
+      )
+    };
+  }
+  throw new Error(`Unsupported platform: ${platform}`);
+}
+
+export function nativeManifest(binaryPath) {
+  return {
+    name: HOST_NAME,
+    description: "Codex Firefox native-messaging bridge",
+    path: binaryPath,
+    type: "stdio",
+    allowed_extensions: [GECKO_EXTENSION_ID]
+  };
+}
+
+export function expectedChecksum(contents, assetName) {
+  for (const line of contents.split(/\r?\n/gu)) {
+    const match = line.trim().match(/^([a-f0-9]{64})\s+\*?(.+)$/iu);
+    if (match && path.basename(match[2]) === assetName) {
+      return match[1].toLowerCase();
+    }
+  }
+  throw new Error(`No checksum was published for ${assetName}.`);
+}
+
+export function assertSafeInstallDirectory(directory, platform = process.platform) {
+  const resolved = path.resolve(directory);
+  const expectedName = "Codex Firefox Bridge";
+  if (path.basename(resolved) !== expectedName) {
+    throw new Error(`Refusing to modify unexpected install directory: ${resolved}`);
+  }
+  if (platform === "win32" && !process.env.LOCALAPPDATA) {
+    throw new Error("LOCALAPPDATA is unavailable.");
+  }
+  return resolved;
+}
+
+export function readInstalledManifest(manifestPath) {
+  const value = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (
+    value.name !== HOST_NAME ||
+    !value.allowed_extensions?.includes(GECKO_EXTENSION_ID)
+  ) {
+    throw new Error("The registered native-host manifest is not this bridge.");
+  }
+  return value;
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "codex-firefox-bridge",
+  "version": "1.4.0",
+  "description": "Install and manage the Codex native-messaging bridge for Firefox and Zen",
+  "type": "module",
+  "bin": {
+    "codex-firefox-bridge": "cli.mjs"
+  },
+  "files": [
+    "cli.mjs",
+    "lib.mjs",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "codex",
+    "firefox",
+    "zen-browser",
+    "native-messaging"
+  ],
+  "homepage": "https://github.com/SunkenInTime/codex-computer-use-firefox-zen",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SunkenInTime/codex-computer-use-firefox-zen.git",
+    "directory": "npm"
+  },
+  "bugs": "https://github.com/SunkenInTime/codex-computer-use-firefox-zen/issues",
+  "license": "UNLICENSED",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/npm/test/lib.test.mjs
+++ b/npm/test/lib.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import {
+  checksumAsset,
+  expectedChecksum,
+  installLocations,
+  nativeManifest,
+  platformAsset
+} from "../lib.mjs";
+
+test("selects release assets for every supported platform", () => {
+  assert.equal(
+    platformAsset("1.4.0", "win32", "x64"),
+    "codex-firefox-bridge-1.4.0-windows-x64.exe"
+  );
+  assert.equal(
+    platformAsset("1.4.0", "darwin", "arm64"),
+    "codex-firefox-bridge-1.4.0-macos-universal"
+  );
+  assert.equal(
+    platformAsset("1.4.0", "darwin", "x64"),
+    "codex-firefox-bridge-1.4.0-macos-universal"
+  );
+  assert.equal(
+    checksumAsset("1.4.0", "darwin"),
+    "codex-firefox-bridge-1.4.0-macos-universal.sha256"
+  );
+});
+
+test("extracts the matching checksum from multi-file checksum lists", () => {
+  const contents = [
+    `${"a".repeat(64)}  installer.exe`,
+    `${"b".repeat(64)}  codex-firefox-bridge-1.4.0-windows-x64.exe`
+  ].join("\n");
+  assert.equal(
+    expectedChecksum(contents, "codex-firefox-bridge-1.4.0-windows-x64.exe"),
+    "b".repeat(64)
+  );
+});
+
+test("generates Firefox native-host manifests", () => {
+  const manifest = nativeManifest("/tmp/bridge");
+  assert.equal(manifest.name, "com.openai.codexextension");
+  assert.equal(manifest.path, "/tmp/bridge");
+  assert.deepEqual(manifest.allowed_extensions, [
+    "codex-computer-use-firefox-zen@sunkenintime"
+  ]);
+});
+
+test("uses per-user installation locations", () => {
+  const windows = installLocations(
+    "win32",
+    { LOCALAPPDATA: "C:\\Users\\test\\AppData\\Local" },
+    "/unused"
+  );
+  assert.equal(
+    windows.directory,
+    path.win32.join("C:\\Users\\test\\AppData\\Local", "Codex Firefox Bridge")
+  );
+  const macos = installLocations("darwin", {}, "/Users/test");
+  assert.equal(
+    macos.manifest,
+    "/Users/test/Library/Application Support/Mozilla/NativeMessagingHosts/com.openai.codexextension.json"
+  );
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-computer-use-firefox-zen",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Codex computer-use compatibility port for Firefox and Zen Browser",
   "scripts": {
     "check": "node scripts/check-version.mjs && node scripts/verify-extension.mjs",

--- a/scripts/check-version.mjs
+++ b/scripts/check-version.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 const release = JSON.parse(fs.readFileSync("version.json", "utf8"));
 const manifest = JSON.parse(fs.readFileSync("extension/manifest.json", "utf8"));
 const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+const npmPackage = JSON.parse(fs.readFileSync("npm/package.json", "utf8"));
 const cargo = fs.readFileSync("native-host/Cargo.toml", "utf8");
 const cargoVersion = cargo.match(/^version\s*=\s*"([^"]+)"/mu)?.[1];
 const expectedTag = `v${release.version}`;
@@ -10,6 +11,7 @@ const expectedTag = `v${release.version}`;
 for (const [name, actual] of [
   ["extension manifest", manifest.version],
   ["package.json", packageJson.version],
+  ["npm package", npmPackage.version],
   ["native companion", cargoVersion]
 ]) {
   if (actual !== release.version) {

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -20,6 +20,9 @@ updateJson("extension/manifest.json", (value) => {
 updateJson("package.json", (value) => {
   value.version = version;
 });
+updateJson("npm/package.json", (value) => {
+  value.version = version;
+});
 
 for (const file of ["native-host/Cargo.toml", "native-host/Cargo.lock"]) {
   const source = fs.readFileSync(file, "utf8");

--- a/scripts/verify-extension.mjs
+++ b/scripts/verify-extension.mjs
@@ -51,6 +51,9 @@ for (const setupFile of ["companion-required.html", "companion-required.css", "c
   assert(existsInExtension(setupFile), `Missing companion setup asset: ${setupFile}`);
 }
 new vm.Script(read("extension/companion-required.js"), { filename: "companion-required.js" });
+const setupHtml = read("extension/companion-required.html");
+assert(setupHtml.includes("codex-firefox-bridge@"), "The npm installation path is missing from setup.");
+assert(setupHtml.includes("Why is this needed?"), "The setup page must explain why the companion is required.");
 for (const [size, icon] of Object.entries(manifest.icons)) {
   assert(existsInExtension(icon), `Missing ${size}px icon: ${icon}`);
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.4.0",
   "upstream_extension_version": "1.2.27203.26576",
   "native_host_name": "com.openai.codexextension",
   "gecko_extension_id": "codex-computer-use-firefox-zen@sunkenintime"


### PR DESCRIPTION
## What changed

- adds the public `codex-firefox-bridge` npm CLI with persistent per-user `install`, `doctor`, and `uninstall` commands
- keeps the Windows `.exe` and macOS universal `.pkg` installers as first-class options
- adds verified raw bridge binaries and an npm tarball to GitHub releases
- adds optional npm publishing with provenance when `NPM_TOKEN` is configured
- bumps the synchronized release version to 1.4.0
- adds the npm path to the extension setup UI with a copy button
- adds a plain-language “Why is this needed?” section to the UI and documentation, including the intent to adopt an official OpenAI Firefox/local connection if one becomes available

## Why

Firefox extensions cannot launch local processes or reuse a native host registered for a Chrome extension. Codex currently exposes this browser connection through its native-host integration rather than a supported Firefox API or authenticated local endpoint, so a small registered companion is required.

## Validation

- `npm test`
- `npm test --prefix npm`
- `npm run package`
- packed tarball invocation: `codex-firefox-bridge --version` → `1.4.0`
- `npx --yes yaml-lint .github/workflows/release.yml`
- `git diff --check`

Native Rust rebuilding remains covered by the Windows and macOS release runners; `cargo` is not installed on this workstation.