### PR TITLE
Fix missing bridge onboarding

### DIFF
--- a/extension/firefox-compat.js
+++ b/extension/firefox-compat.js
@@ -59,16 +59,9 @@
       if (receivedNativeMessage) {
         return;
       }
-      const error = firefox.runtime.lastError?.message ?? "";
-      if (
-        !error.includes("native messaging host") &&
-        !error.includes("Native host has exited")
-      ) {
-        return;
-      }
       firefox.action.setBadgeBackgroundColor({ color: "#d97706" }).catch(() => {});
       firefox.action.setBadgeText({ text: "SETUP" }).catch(() => {});
-      const storageKey = `companionSetupShown:${firefox.runtime.getManifest().version}`;
+      const storageKey = `companionSetupPromptShown:${firefox.runtime.getManifest().version}`;
       firefox.storage.local.get(storageKey).then((stored) => {
         if (stored[storageKey]) {
           return;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Codex Computer Use for Zen & Fox",
   "description": "Bring Codex computer use and its signed-in sidebar to Firefox and Zen Browser.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "icons": {
     "16": "images/firefox-zen-icon16.png",
     "32": "images/firefox-zen-icon32.png",

--- a/native-host/Cargo.lock
+++ b/native-host/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "codex-firefox-bridge"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "base64",
  "regex",

--- a/native-host/Cargo.toml
+++ b/native-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-firefox-bridge"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 description = "Firefox native-messaging bridge for the installed OpenAI Codex extension host"
 license = "UNLICENSED"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-firefox-bridge",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Install and manage the Codex native-messaging bridge for Firefox and Zen",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-computer-use-firefox-zen",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Codex computer-use compatibility port for Firefox and Zen Browser",
   "scripts": {
     "check": "node scripts/check-version.mjs && node scripts/verify-extension.mjs",

--- a/scripts/verify-extension.mjs
+++ b/scripts/verify-extension.mjs
@@ -64,7 +64,7 @@ for (const match of sidebarHtml.matchAll(/(?:src|href)="\.\/([^"?#]+)"/gu)) {
 }
 
 const compatibilitySource = read("extension/firefox-compat.js");
-assert(compatibilitySource.includes("companionSetupShown:"), "Missing one-time companion setup guidance.");
+assert(compatibilitySource.includes("companionSetupPromptShown:"), "Missing one-time companion setup guidance.");
 const coreCdpMethods = [
   "DOM.describeNode",
   "DOM.getBoxModel",

--- a/tests/test-firefox-compat.mjs
+++ b/tests/test-firefox-compat.mjs
@@ -12,6 +12,7 @@ class EventMock {
   addListener(listener) { this.listeners.push(listener); }
   removeListener(listener) { this.listeners = this.listeners.filter((candidate) => candidate !== listener); }
   hasListener(listener) { return this.listeners.includes(listener); }
+  emit(...args) { for (const listener of [...this.listeners]) listener(...args); }
 }
 
 const webRequest = {
@@ -26,18 +27,39 @@ const webRequest = {
 };
 const executedTargets = [];
 const executedSources = [];
+const createdTabs = [];
+const storedValues = {};
+const nativePort = {
+  onMessage: new EventMock(),
+  onDisconnect: new EventMock(),
+  postMessage() {},
+  disconnect() {},
+};
 const browser = {
   runtime: {
     id: "codex-computer-use-firefox-zen@sunkenintime", onMessage: new EventMock(),
     async getBrowserInfo() { return { name: "Firefox", version: "152.0", buildID: "test" }; },
-    connectNative() { throw new Error("not used"); },
+    getManifest() { return { version: "test" }; },
+    getURL(pathname) { return `moz-extension://test/${pathname}`; },
+    connectNative() { return nativePort; },
+  },
+  action: {
+    async setBadgeBackgroundColor() {},
+    async setBadgeText() {},
   },
   permissions: { async request() { return true; } },
   sidebarAction: { async open() {}, async close() {} },
+  storage: {
+    local: {
+      async get(key) { return { [key]: storedValues[key] }; },
+      async set(values) { Object.assign(storedValues, values); },
+    },
+  },
   tabs: {
     onUpdated: new EventMock(), onRemoved: new EventMock(),
     async query() { return [{ id: 1, windowId: 10, url: "https://top.test/", title: "Top", active: true }]; },
     async get() { return { id: 1, windowId: 10, url: "https://top.test/", title: "Top", active: true }; },
+    async create(details) { createdTabs.push(details); },
     async update() {}, async remove() {}, async reload() {}, async setZoom() {},
     async captureTab() { return "data:image/png;base64,dGVzdA=="; },
   },
@@ -86,6 +108,12 @@ const context = vm.createContext({
 new vm.Script(source, { filename: "firefox-compat.js" }).runInContext(context);
 const compat = context.__chatgptFirefoxCompat;
 assert.ok(compat?.debugger, "Compatibility debugger was not installed.");
+
+context.chrome.runtime.connectNative("com.openai.codexextension");
+nativePort.onDisconnect.emit();
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.equal(createdTabs.length, 1, "An immediate native disconnect must open companion setup.");
+assert.equal(createdTabs[0].url, "moz-extension://test/companion-required.html");
 
 const events = [];
 compat.debugger.onEvent.addListener((sourceInfo, method, params) => events.push({ sourceInfo, method, params }));

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.4.1",
   "upstream_extension_version": "1.2.27203.26576",
   "native_host_name": "com.openai.codexextension",
   "gecko_extension_id": "codex-computer-use-firefox-zen@sunkenintime"


### PR DESCRIPTION
## What changed

- Show the companion setup page after any native host disconnect that occurs before the first native message.
- Keep the prompt one-time per extension version.
- Add regression coverage for the immediate-disconnect path.
- Bump the release stack to 1.4.1.

## Why

The AMO-installed 1.4.0 extension correctly reported `Native transport disconnected` on a clean Windows machine, but Firefox's actual missing-host disconnect did not match the narrow error-string filter, so the setup page never opened.

## Impact

Fresh Firefox and Zen installs now reach the Windows/macOS/npm onboarding automatically. Existing healthy installs are unaffected because any host that sends a native message bypasses the prompt.

## Validation

- Full Windows AMO remove/reinstall test
- Clean missing-bridge reproduction
- Temporary Firefox 1.4.1 load with automatic onboarding verified visually
- Public npm 1.4.0 recovery to signed-in `New task` state
- `npm test`
- `web-ext lint`: 0 errors, 0 notices (67 inherited/intentional warnings)