### PR TITLE
Use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,11 +192,9 @@ jobs:
           files: release/*
 
   publish-npm:
-    if: github.ref_type == 'tag'
-    needs: publish
+    if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+    needs: npm-package
     runs-on: ubuntu-latest
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -204,8 +202,4 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
       - name: Publish npm installer with provenance
-        if: env.NODE_AUTH_TOKEN != ''
         run: npm publish ./npm --access public --provenance
-      - name: Explain skipped npm publish
-        if: env.NODE_AUTH_TOKEN == ''
-        run: echo "::notice::NPM_TOKEN is not configured; the npm package was attached to the GitHub release but not published to npm."


### PR DESCRIPTION
## What changed

- Publish npm releases through npm's GitHub Actions OIDC trusted-publisher flow.
- Allow a manual workflow dispatch to recover an npm publish without minting another release tag.
- Remove the legacy `NPM_TOKEN`/skip branch.

## Why

The 1.4.1 tag built and published every GitHub artifact successfully, but the token-based npm job failed repeatedly at the registry. npm is also retiring bypass-2FA token workflows. Trusted publishing gives provenance-backed, tokenless releases and is the supported long-term path.

## Impact

Future semantic-version tags publish npm with OIDC, and an interrupted registry publish can be retried from workflow dispatch after the package's trusted-publisher connection is configured.

## Validation

- `npm test`
- `git diff --check`
- 1.4.1 package was successfully packed and signed for provenance by the existing workflow before the registry rejected the token-based upload.