### PR TITLE
Fix Firefox bridge app-server startup on macOS

### DIFF
--- a/native-host/Cargo.lock
+++ b/native-host/Cargo.lock
@@ -18,12 +18,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "codex-firefox-bridge"
 version = "1.4.2"
 dependencies = [
  "base64",
  "regex",
  "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -33,10 +73,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "proc-macro2"
@@ -55,6 +113,12 @@ checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "regex"
@@ -84,6 +148,19 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "serde"
@@ -139,10 +216,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/native-host/Cargo.toml
+++ b/native-host/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 base64 = "0.22"
 regex = "1.11"
 serde_json = "1.0"
+tempfile = "3.20"
 
 [profile.release]
 lto = true

--- a/native-host/src/main.rs
+++ b/native-host/src/main.rs
@@ -3,20 +3,22 @@ use regex::{Captures, Regex};
 use serde_json::{json, Value};
 use std::env;
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{ChildStderr, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::thread;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tempfile::TempDir;
 
 const HOST_NAME: &str = "com.openai.codexextension";
 const OFFICIAL_CHROME_ORIGIN: &str = "chrome-extension://hehggadaopoacecdllhhajmbjkdcmajg/";
 const OFFICIAL_CHROME_EXTENSION_ID: &str = "hehggadaopoacecdllhhajmbjkdcmajg";
 const FIREFOX_EXTENSION_ID: &str = "codex-computer-use-firefox-zen@sunkenintime";
 const MAX_NATIVE_MESSAGE_BYTES: usize = 1024 * 1024 * 1024;
+const CODEX_VERSION_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, PartialEq)]
 struct AppServerRuntime {
@@ -46,13 +48,17 @@ fn main() {
         }
     }
 
-    if let Err(error) = run() {
-        eprintln!("[codex-firefox-bridge] {error}");
-        std::process::exit(1);
+    match run() {
+        Ok(0) => {}
+        Ok(code) => std::process::exit(code),
+        Err(error) => {
+            eprintln!("[codex-firefox-bridge] {error}");
+            std::process::exit(1);
+        }
     }
 }
 
-fn run() -> Result<(), Box<dyn std::error::Error>> {
+fn run() -> Result<i32, Box<dyn std::error::Error>> {
     let listener = TcpListener::bind(("127.0.0.1", 0))?;
     let relay_port = listener.local_addr()?.port();
     let upstream_port = Arc::new(AtomicU16::new(0));
@@ -94,13 +100,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let _ = output_thread.join();
     let _ = error_thread.join();
     drop(input_thread);
-    if let Some(directory) = fallback_registry {
-        let _ = fs::remove_dir_all(directory);
-    }
-    std::process::exit(status.code().unwrap_or(1));
+    drop(fallback_registry);
+    Ok(status.code().unwrap_or(1))
 }
 
-fn configure_app_server_runtime(command: &mut Command, host_path: &Path) -> Option<PathBuf> {
+fn configure_app_server_runtime(command: &mut Command, host_path: &Path) -> Option<TempDir> {
     let runtime = discover_app_server_runtime()?;
     for (variable, value) in [
         ("CODEX_CLI_PATH", runtime.codex_cli.clone()),
@@ -117,7 +121,7 @@ fn configure_app_server_runtime(command: &mut Command, host_path: &Path) -> Opti
         return None;
     }
     let directory = create_fallback_app_server_registry(host_path, &runtime).ok()?;
-    command.env("CODEX_HOME", &directory);
+    command.env("CODEX_HOME", directory.path());
     Some(directory)
 }
 
@@ -201,12 +205,10 @@ fn registry_has_entries(path: &Path) -> bool {
 fn create_fallback_app_server_registry(
     host_path: &Path,
     runtime: &AppServerRuntime,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let directory = env::temp_dir().join(format!(
-        "codex-firefox-bridge-runtime-{}",
-        std::process::id()
-    ));
-    fs::create_dir_all(&directory)?;
+) -> Result<TempDir, Box<dyn std::error::Error>> {
+    let directory = tempfile::Builder::new()
+        .prefix("codex-firefox-bridge-runtime-")
+        .tempdir()?;
     let codex_home = env::var_os("CODEX_HOME")
         .map(PathBuf::from)
         .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".codex")))
@@ -224,7 +226,7 @@ fn create_fallback_app_server_registry(
         &updated_at,
     );
     fs::write(
-        directory.join("chrome-native-hosts-v2.json"),
+        directory.path().join("chrome-native-hosts-v2.json"),
         serde_json::to_vec_pretty(&json!({
             "schemaVersion": 2,
             "entries": [entry]
@@ -277,10 +279,38 @@ fn bundled_plugin_version(resources: &Path) -> Option<String> {
 }
 
 fn codex_cli_version(codex_cli: &Path) -> Option<String> {
-    let output = Command::new(codex_cli).arg("--version").output().ok()?;
-    let version = String::from_utf8_lossy(&output.stdout);
-    output.status.success().then(|| {
-        let version = version.trim();
+    codex_cli_version_with_timeout(codex_cli, CODEX_VERSION_TIMEOUT)
+}
+
+fn codex_cli_version_with_timeout(codex_cli: &Path, timeout: Duration) -> Option<String> {
+    let mut stdout = tempfile::tempfile().ok()?;
+    let child_stdout = stdout.try_clone().ok()?;
+    let mut child = Command::new(codex_cli)
+        .arg("--version")
+        .stdout(Stdio::from(child_stdout))
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        if let Some(status) = child.try_wait().ok()? {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+    if !status.success() {
+        return None;
+    }
+    stdout.seek(SeekFrom::Start(0)).ok()?;
+    let mut output = String::new();
+    stdout.read_to_string(&mut output).ok()?;
+    Some({
+        let version = output.trim();
         version
             .strip_prefix("codex-cli ")
             .unwrap_or(version)
@@ -836,8 +866,8 @@ mod tests {
 
     #[test]
     fn discovers_a_complete_bundled_app_server_runtime() {
-        let temp =
-            env::temp_dir().join(format!("codex-firefox-runtime-test-{}", std::process::id()));
+        let directory = tempfile::tempdir().unwrap();
+        let temp = directory.path();
         let browser_client =
             temp.join("plugins/openai-bundled/plugins/chrome/scripts/browser-client.mjs");
         for path in [
@@ -851,7 +881,7 @@ mod tests {
         }
 
         assert_eq!(
-            app_server_runtime_from_resources(&temp),
+            app_server_runtime_from_resources(temp),
             Some(AppServerRuntime {
                 codex_cli: temp.join("codex"),
                 node: temp.join("cua_node/bin/node"),
@@ -859,7 +889,6 @@ mod tests {
                 node_repl: temp.join("cua_node/bin/node_repl"),
             })
         );
-        fs::remove_dir_all(temp).unwrap();
     }
 
     #[test]
@@ -903,18 +932,32 @@ mod tests {
 
     #[test]
     fn detects_nonempty_v2_registries() {
-        let path = env::temp_dir().join(format!(
-            "codex-firefox-registry-test-{}.json",
-            std::process::id()
-        ));
-        fs::write(&path, r#"{"schemaVersion":2,"entries":[]}"#).unwrap();
-        assert!(!registry_has_entries(&path));
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let path = file.path();
+        fs::write(path, r#"{"schemaVersion":2,"entries":[]}"#).unwrap();
+        assert!(!registry_has_entries(path));
         fs::write(
-            &path,
+            path,
             r#"{"schemaVersion":2,"entries":[{"entryId":"test"}]}"#,
         )
         .unwrap();
-        assert!(registry_has_entries(&path));
-        fs::remove_file(path).unwrap();
+        assert!(registry_has_entries(path));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounds_the_codex_version_probe() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let script = directory.path().join("slow-codex");
+        fs::write(&script, "#!/bin/sh\nsleep 5\n").unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o700)).unwrap();
+        let started = Instant::now();
+        assert_eq!(
+            codex_cli_version_with_timeout(&script, Duration::from_millis(50)),
+            None
+        );
+        assert!(started.elapsed() < Duration::from_secs(1));
     }
 }

--- a/native-host/src/main.rs
+++ b/native-host/src/main.rs
@@ -10,10 +10,21 @@ use std::process::{ChildStderr, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const HOST_NAME: &str = "com.openai.codexextension";
 const OFFICIAL_CHROME_ORIGIN: &str = "chrome-extension://hehggadaopoacecdllhhajmbjkdcmajg/";
+const OFFICIAL_CHROME_EXTENSION_ID: &str = "hehggadaopoacecdllhhajmbjkdcmajg";
+const FIREFOX_EXTENSION_ID: &str = "codex-computer-use-firefox-zen@sunkenintime";
 const MAX_NATIVE_MESSAGE_BYTES: usize = 1024 * 1024 * 1024;
+
+#[derive(Debug, PartialEq)]
+struct AppServerRuntime {
+    codex_cli: PathBuf,
+    node: PathBuf,
+    browser_client: PathBuf,
+    node_repl: PathBuf,
+}
 
 fn main() {
     let argument = env::args().nth(1);
@@ -49,6 +60,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let host_path = discover_original_host()?;
     let mut command = Command::new(&host_path);
+    let fallback_registry = configure_app_server_runtime(&mut command, &host_path);
     command
         .arg(OFFICIAL_CHROME_ORIGIN)
         .current_dir(host_path.parent().unwrap_or_else(|| Path::new(".")))
@@ -82,13 +94,275 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let _ = output_thread.join();
     let _ = error_thread.join();
     drop(input_thread);
+    if let Some(directory) = fallback_registry {
+        let _ = fs::remove_dir_all(directory);
+    }
     std::process::exit(status.code().unwrap_or(1));
 }
 
-fn forward_stdin(mut output: ChildStdin) {
-    if let Err(error) = io::copy(&mut io::stdin().lock(), &mut output) {
-        eprintln!("[codex-firefox-bridge] stdin forwarding failed: {error}");
+fn configure_app_server_runtime(command: &mut Command, host_path: &Path) -> Option<PathBuf> {
+    let runtime = discover_app_server_runtime()?;
+    for (variable, value) in [
+        ("CODEX_CLI_PATH", runtime.codex_cli.clone()),
+        ("CODEX_BROWSER_USE_NODE_PATH", runtime.node.clone()),
+        ("CODEX_BROWSER_CLIENT_PATH", runtime.browser_client.clone()),
+        ("CODEX_NODE_REPL_PATH", runtime.node_repl.clone()),
+    ] {
+        if env::var_os(variable).is_none() {
+            command.env(variable, value);
+        }
     }
+
+    if has_registered_app_server() {
+        return None;
+    }
+    let directory = create_fallback_app_server_registry(host_path, &runtime).ok()?;
+    command.env("CODEX_HOME", &directory);
+    Some(directory)
+}
+
+fn discover_app_server_runtime() -> Option<AppServerRuntime> {
+    app_server_resource_candidates()
+        .into_iter()
+        .find_map(|resources| app_server_runtime_from_resources(&resources))
+}
+
+fn app_server_resource_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(resources) = env::var_os("CODEX_FIREFOX_CHATGPT_RESOURCES") {
+        candidates.push(PathBuf::from(resources));
+    }
+    if cfg!(target_os = "macos") {
+        candidates.push(PathBuf::from(
+            "/Applications/ChatGPT.app/Contents/Resources",
+        ));
+        if let Some(home) = env::var_os("HOME").map(PathBuf::from) {
+            candidates.push(home.join("Applications/ChatGPT.app/Contents/Resources"));
+        }
+    }
+    candidates
+}
+
+fn app_server_runtime_from_resources(resources: &Path) -> Option<AppServerRuntime> {
+    let runtime = AppServerRuntime {
+        codex_cli: resources.join("codex"),
+        node: resources.join("cua_node/bin/node"),
+        browser_client: resources
+            .join("plugins/openai-bundled/plugins/chrome/scripts/browser-client.mjs"),
+        node_repl: resources.join("cua_node/bin/node_repl"),
+    };
+    [
+        &runtime.codex_cli,
+        &runtime.node,
+        &runtime.browser_client,
+        &runtime.node_repl,
+    ]
+    .iter()
+    .all(|path| path.is_file())
+    .then_some(runtime)
+}
+
+fn has_registered_app_server() -> bool {
+    app_server_registry_candidates()
+        .iter()
+        .any(|path| registry_has_entries(path))
+}
+
+fn app_server_registry_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(codex_home) = env::var_os("CODEX_HOME").map(PathBuf::from) {
+        candidates.push(codex_home.join("chrome-native-hosts-v2.json"));
+    }
+    if let Some(home) = env::var_os("HOME").map(PathBuf::from) {
+        candidates.push(home.join(".codex/chrome-native-hosts-v2.json"));
+        if cfg!(target_os = "macos") {
+            candidates.push(
+                home.join("Library/Application Support/OpenAI/Codex")
+                    .join("chrome-native-hosts-v2.json"),
+            );
+        }
+    }
+    candidates
+}
+
+fn registry_has_entries(path: &Path) -> bool {
+    let Ok(bytes) = fs::read(path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_slice::<Value>(&bytes) else {
+        return false;
+    };
+    value
+        .get("entries")
+        .and_then(Value::as_array)
+        .is_some_and(|entries| !entries.is_empty())
+}
+
+fn create_fallback_app_server_registry(
+    host_path: &Path,
+    runtime: &AppServerRuntime,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let directory = env::temp_dir().join(format!(
+        "codex-firefox-bridge-runtime-{}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&directory)?;
+    let codex_home = env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".codex")))
+        .ok_or("Codex home directory is unavailable")?;
+    let resources = runtime.codex_cli.parent().ok_or("Invalid Codex CLI path")?;
+    let app_version = bundled_plugin_version(resources).unwrap_or_else(|| "0.0.0".into());
+    let cli_version = codex_cli_version(&runtime.codex_cli).unwrap_or_else(|| "0.0.0".into());
+    let updated_at = current_timestamp();
+    let entry = fallback_registry_entry(
+        host_path,
+        runtime,
+        &codex_home,
+        &app_version,
+        &cli_version,
+        &updated_at,
+    );
+    fs::write(
+        directory.join("chrome-native-hosts-v2.json"),
+        serde_json::to_vec_pretty(&json!({
+            "schemaVersion": 2,
+            "entries": [entry]
+        }))?,
+    )?;
+    Ok(directory)
+}
+
+fn fallback_registry_entry(
+    host_path: &Path,
+    runtime: &AppServerRuntime,
+    codex_home: &Path,
+    app_version: &str,
+    cli_version: &str,
+    updated_at: &str,
+) -> Value {
+    let resources = runtime.codex_cli.parent().unwrap_or_else(|| Path::new("."));
+    json!({
+        "schemaVersion": 2,
+        "appServerProtocolVersion": 2,
+        "appVersion": app_version,
+        "channel": "prod",
+        "cliVersion": cli_version,
+        "entryId": "codex-firefox-bridge-current-chatgpt",
+        "extensionBuildChannels": ["prod"],
+        "extensionIds": [OFFICIAL_CHROME_EXTENSION_ID, FIREFOX_EXTENSION_ID],
+        "installId": "codex-firefox-bridge-current-chatgpt",
+        "nativeHostNames": [HOST_NAME],
+        "nativeHostProtocolVersion": 2,
+        "nativeHostVersion": "0.1.0",
+        "paths": {
+            "browserClientPath": runtime.browser_client,
+            "codexCliPath": runtime.codex_cli,
+            "codexHome": codex_home,
+            "extensionHostPath": host_path,
+            "nodePath": runtime.node,
+            "nodeReplPath": runtime.node_repl,
+            "resourcesPath": resources
+        },
+        "proxyHost": "127.0.0.1",
+        "proxyPort": 0,
+        "updatedAt": updated_at
+    })
+}
+
+fn bundled_plugin_version(resources: &Path) -> Option<String> {
+    let path = resources.join("plugins/openai-bundled/plugins/chrome/.codex-plugin/plugin.json");
+    let value: Value = serde_json::from_slice(&fs::read(path).ok()?).ok()?;
+    value.get("version")?.as_str().map(ToOwned::to_owned)
+}
+
+fn codex_cli_version(codex_cli: &Path) -> Option<String> {
+    let output = Command::new(codex_cli).arg("--version").output().ok()?;
+    let version = String::from_utf8_lossy(&output.stdout);
+    output.status.success().then(|| {
+        let version = version.trim();
+        version
+            .strip_prefix("codex-cli ")
+            .unwrap_or(version)
+            .to_owned()
+    })
+}
+
+fn current_timestamp() -> String {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    format!("unix-{seconds}")
+}
+
+fn forward_stdin(mut output: ChildStdin) {
+    let mut input = io::stdin().lock();
+    loop {
+        let mut header = [0_u8; 4];
+        match read_exact_or_eof(&mut input, &mut header) {
+            Ok(false) => return,
+            Ok(true) => {}
+            Err(error) => {
+                eprintln!("[codex-firefox-bridge] native input header read failed: {error}");
+                return;
+            }
+        }
+        let length = u32::from_le_bytes(header) as usize;
+        if length > MAX_NATIVE_MESSAGE_BYTES {
+            eprintln!("[codex-firefox-bridge] native input message is too large: {length}");
+            return;
+        }
+        let mut payload = vec![0_u8; length];
+        if let Err(error) = input.read_exact(&mut payload) {
+            eprintln!("[codex-firefox-bridge] native input payload read failed: {error}");
+            return;
+        }
+        let rewritten = rewrite_native_request(payload);
+        let rewritten_header = (rewritten.len() as u32).to_le_bytes();
+        if output
+            .write_all(&rewritten_header)
+            .and_then(|_| output.write_all(&rewritten))
+            .and_then(|_| output.flush())
+            .is_err()
+        {
+            return;
+        }
+    }
+}
+
+fn rewrite_native_request(payload: Vec<u8>) -> Vec<u8> {
+    let Ok(mut value) = serde_json::from_slice::<Value>(&payload) else {
+        return payload;
+    };
+    if !rewrite_firefox_extension_id(&mut value) {
+        return payload;
+    }
+    serde_json::to_vec(&value).unwrap_or(payload)
+}
+
+fn rewrite_firefox_extension_id(value: &mut Value) -> bool {
+    let mut changed = false;
+    match value {
+        Value::String(text) => {
+            if text == FIREFOX_EXTENSION_ID {
+                *text = OFFICIAL_CHROME_EXTENSION_ID.into();
+                changed = true;
+            }
+        }
+        Value::Object(object) => {
+            for child in object.values_mut() {
+                changed |= rewrite_firefox_extension_id(child);
+            }
+        }
+        Value::Array(array) => {
+            for child in array {
+                changed |= rewrite_firefox_extension_id(child);
+            }
+        }
+        _ => {}
+    }
+    changed
 }
 
 fn forward_stderr(mut input: ChildStderr) {
@@ -350,7 +624,10 @@ fn rewrite_websocket_request(request: &str, upstream_port: u16) -> String {
         .map(|line| {
             let lower = line.to_ascii_lowercase();
             if lower.starts_with("origin:") {
-                format!("Origin: {OFFICIAL_CHROME_ORIGIN}\r\n")
+                format!(
+                    "Origin: {}\r\n",
+                    OFFICIAL_CHROME_ORIGIN.trim_end_matches('/')
+                )
             } else if lower.starts_with("host:") {
                 format!("Host: 127.0.0.1:{upstream_port}\r\n")
             } else {
@@ -520,11 +797,32 @@ mod tests {
     }
 
     #[test]
+    fn presents_firefox_requests_as_the_official_chrome_extension() {
+        let payload = serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "method": "codexRuntime/ensure",
+            "params": {
+                "constraints": {
+                    "extensionId": FIREFOX_EXTENSION_ID
+                }
+            }
+        }))
+        .unwrap();
+        let rewritten: Value = serde_json::from_slice(&rewrite_native_request(payload)).unwrap();
+        assert_eq!(
+            rewritten["params"]["constraints"]["extensionId"],
+            OFFICIAL_CHROME_EXTENSION_ID
+        );
+    }
+
+    #[test]
     fn rewrites_websocket_origin_and_host() {
         let request = "GET / HTTP/1.1\r\nHost: 127.0.0.1:1\r\nOrigin: moz-extension://abc\r\n\r\n";
         let rewritten = rewrite_websocket_request(request, 45678);
         assert!(rewritten.contains("Host: 127.0.0.1:45678\r\n"));
-        assert!(rewritten.contains(&format!("Origin: {OFFICIAL_CHROME_ORIGIN}\r\n")));
+        assert!(
+            rewritten.contains("Origin: chrome-extension://hehggadaopoacecdllhhajmbjkdcmajg\r\n")
+        );
     }
 
     #[test]
@@ -534,5 +832,89 @@ mod tests {
             paths[0],
             Path::new("/Users/test/.codex/plugins/cache/openai-bundled/chrome/latest/extension-host/macos/arm64/ChatGPT for Chrome")
         );
+    }
+
+    #[test]
+    fn discovers_a_complete_bundled_app_server_runtime() {
+        let temp =
+            env::temp_dir().join(format!("codex-firefox-runtime-test-{}", std::process::id()));
+        let browser_client =
+            temp.join("plugins/openai-bundled/plugins/chrome/scripts/browser-client.mjs");
+        for path in [
+            temp.join("codex"),
+            temp.join("cua_node/bin/node"),
+            temp.join("cua_node/bin/node_repl"),
+            browser_client.clone(),
+        ] {
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, "").unwrap();
+        }
+
+        assert_eq!(
+            app_server_runtime_from_resources(&temp),
+            Some(AppServerRuntime {
+                codex_cli: temp.join("codex"),
+                node: temp.join("cua_node/bin/node"),
+                browser_client,
+                node_repl: temp.join("cua_node/bin/node_repl"),
+            })
+        );
+        fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[test]
+    fn rejects_an_incomplete_bundled_app_server_runtime() {
+        let missing = env::temp_dir().join("codex-firefox-missing-runtime");
+        assert_eq!(app_server_runtime_from_resources(&missing), None);
+    }
+
+    #[test]
+    fn creates_a_v2_fallback_registry_entry_for_firefox() {
+        let runtime = AppServerRuntime {
+            codex_cli: PathBuf::from("/Applications/ChatGPT.app/Contents/Resources/codex"),
+            node: PathBuf::from("/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"),
+            browser_client: PathBuf::from(
+                "/Applications/ChatGPT.app/Contents/Resources/plugins/openai-bundled/plugins/chrome/scripts/browser-client.mjs",
+            ),
+            node_repl: PathBuf::from(
+                "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node_repl",
+            ),
+        };
+        let entry = fallback_registry_entry(
+            Path::new("/native/ChatGPT for Chrome"),
+            &runtime,
+            Path::new("/Users/test/.codex"),
+            "26.721.41059",
+            "0.146.0-alpha.3.1",
+            "test-time",
+        );
+        assert_eq!(entry["schemaVersion"], 2);
+        assert_eq!(entry["appServerProtocolVersion"], 2);
+        assert_eq!(entry["extensionIds"][1], FIREFOX_EXTENSION_ID);
+        assert_eq!(
+            entry["paths"]["codexCliPath"].as_str(),
+            runtime.codex_cli.to_str()
+        );
+        assert_eq!(
+            entry["paths"]["extensionHostPath"],
+            "/native/ChatGPT for Chrome"
+        );
+    }
+
+    #[test]
+    fn detects_nonempty_v2_registries() {
+        let path = env::temp_dir().join(format!(
+            "codex-firefox-registry-test-{}.json",
+            std::process::id()
+        ));
+        fs::write(&path, r#"{"schemaVersion":2,"entries":[]}"#).unwrap();
+        assert!(!registry_has_entries(&path));
+        fs::write(
+            &path,
+            r#"{"schemaVersion":2,"entries":[{"entryId":"test"}]}"#,
+        )
+        .unwrap();
+        assert!(registry_has_entries(&path));
+        fs::remove_file(path).unwrap();
     }
 }

--- a/scripts/register-native-host.sh
+++ b/scripts/register-native-host.sh
@@ -9,6 +9,7 @@ manifest_dir="$HOME/Library/Application Support/Mozilla/NativeMessagingHosts"
 cargo build --release --locked --manifest-path "$root/native-host/Cargo.toml"
 mkdir -p "$install_dir" "$manifest_dir"
 cp "$root/native-host/target/release/codex-firefox-bridge" "$install_dir/codex-firefox-bridge"
+codesign --force --sign - "$install_dir/codex-firefox-bridge"
 node - "$root/installer/macos/com.openai.codexextension.json" \
   "$manifest_dir/com.openai.codexextension.json" \
   "$install_dir/codex-firefox-bridge" <<'NODE'


### PR DESCRIPTION
## What changed

- Discover the current ChatGPT-bundled Codex CLI, browser client, Node, and Node REPL runtime on macOS.
- When the normal v2 app-server registries contain no entries, give the OpenAI native host a process-local fallback v2 registration. Existing non-empty registrations remain authoritative.
- Translate the Firefox add-on ID to the official Chrome extension ID in native requests so the host-issued WebSocket capability is bound to the same identity used by the relay's rewritten Origin.
- Normalize the relayed WebSocket Origin and ad-hoc sign locally built bridge binaries in the macOS developer installer.

## Root cause

The 1.4.2 sidebar-open bookkeeping works, and Firefox connects to the bridge and OpenAI native host. Startup still failed because both `chrome-native-hosts-v2.json` registries were empty, while the legacy registry pointed at the removed `/Applications/Codex.app` runtime. That made `codexRuntime/ensure` return `no_matching_codex_install`.

After supplying the current ChatGPT runtime, the app server started, but its WebSocket gateway returned 403 because the capability was issued for the Firefox extension ID while the relay presented the official Chrome Origin. Translating the native request identity makes those two sides consistent.

## Impact

Zen/Firefox can start the local ChatGPT app server from the sidebar even when the desktop app has not populated a v2 Chrome-host registry, without replacing or mutating the user's real registry files.

## Validation

- `cargo test --manifest-path native-host/Cargo.toml` — 8 passed
- `cargo clippy --manifest-path native-host/Cargo.toml --all-targets -- -D warnings` — passed
- `npm test` — passed
- Direct Firefox-shaped native `hello` + `ensure` + relayed WebSocket smoke test — `HTTP/1.1 101 Switching Protocols`
- `web-ext lint` still reports the existing reserved `data_collection_permissions` manifest property and packaged-bundle warnings; this PR does not change extension manifest or bundled UI files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Firefox-specific fallback runtime registry (v2) for the native host bridge.
  * Improved request/handshake compatibility by translating Firefox-originated IDs and updating the WebSocket `Origin` header.
  * Added automatic macOS code signing during native host installation.
* **Bug Fixes**
  * Strengthened native message forwarding using framed length-delimited payloads with size limits.
  * Added resilient JSON rewriting (when possible) for runtime constraints and updated handshake expectations.
* **Tests**
  * Expanded unit coverage for v2 runtime discovery, fallback registry generation, and version-probing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->