### PR TITLE
Release Firefox bridge 1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ This project follows semantic versioning. The Firefox add-on and native companio
 always share one version and are released from a matching `vMAJOR.MINOR.PATCH`
 Git tag.
 
+## 1.4.5 - 2026-08-11
+
+- Advertised an explicit `Codex Firefox Bridge (Firefox/Zen)` browser name and
+  structured Firefox-versus-Chrome-compatibility metadata to browser-control
+  clients, so diagnostics can identify the real browser without changing the
+  Chrome-compatible transport contract.
+- Added a Firefox sidebar preflight that explains and requests all-websites host
+  access before Codex starts, preventing automation from failing only after a
+  navigation or new-tab transition.
+- Replaced Firefox's raw missing-host-permission failure with actionable recovery
+  guidance when website access is revoked while Codex is running.
+- Added a `tabs.captureVisibleTab` fallback for Zen builds that do not expose
+  Firefox's nominal `tabs.captureTab` API.
+
 ## 1.4.4 - 2026-08-03
 
 - Resynced the complete inherited OpenAI extension distribution from packaged

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The original OpenAI sidebar and background application are retained. The compati
 
 - Firefox `sidebar_action` support in place of Chrome `sidePanel`;
 - a persistent Firefox background page in place of a Manifest V3 service worker;
+- explicit `Codex Firefox Bridge (Firefox/Zen)` discovery metadata while retaining
+  the official host's Chrome-compatible transport family;
 - translation of the `chrome.debugger`/CDP operations used by OpenAI's browser-control client into Firefox tab, cookie, screenshot, scripting, DOM, and input APIs;
 - a native-messaging adapter that securely relays to the locally installed official OpenAI extension host;
 - local-file transfer for controlled file inputs;
@@ -120,7 +122,8 @@ The OpenAI native extension host must already be installed by ChatGPT/Codex tool
 2. In Zen or Firefox, open `about:debugging#/runtime/this-firefox`.
 3. Select **Load Temporary Add-on**, then choose `extension/manifest.json`.
 4. Open the Codex computer-use sidebar from the toolbar button or its configured shortcut.
-5. Start a Codex computer-use task. Page execution uses Firefox's standard `scripting.executeScript` API; the add-on does not request the user-script-manager-only `userScripts` permission.
+5. If prompted, choose **Allow all websites**. Firefox requires this host access before Codex can continue controlling a page after navigation or in a newly opened tab. You can revoke it later from **Add-ons and themes → Codex Computer Use for Zen & Fox → Permissions and data**.
+6. Start a Codex computer-use task. Page execution uses Firefox's standard `scripting.executeScript` API; the add-on does not request the user-script-manager-only `userScripts` permission.
 
 Temporary add-ons are removed when the browser exits. Permanent installation requires Mozilla signing while retaining the Gecko ID `codex-computer-use-firefox-zen@sunkenintime`.
 

--- a/extension/codex-sidepanel/firefox-host-access.css
+++ b/extension/codex-sidepanel/firefox-host-access.css
@@ -1,0 +1,64 @@
+.firefox-host-access {
+  align-items: center;
+  background: Canvas;
+  box-sizing: border-box;
+  color: CanvasText;
+  display: flex;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.firefox-host-access__card {
+  margin: 0 auto;
+  max-width: 420px;
+}
+
+.firefox-host-access__icon {
+  font-size: 32px;
+  margin-bottom: 16px;
+}
+
+.firefox-host-access__title {
+  font-size: 22px;
+  margin: 0 0 12px;
+}
+
+.firefox-host-access__copy {
+  font-size: 15px;
+  line-height: 1.5;
+  margin: 0 0 12px;
+}
+
+.firefox-host-access__copy--muted,
+.firefox-host-access__status {
+  color: GrayText;
+  font-size: 13px;
+}
+
+.firefox-host-access__button {
+  background: #0d6efd;
+  border: 0;
+  border-radius: 999px;
+  color: white;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  margin-top: 8px;
+  padding: 10px 18px;
+}
+
+.firefox-host-access__button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.firefox-host-access__button:focus-visible {
+  outline: 3px solid Highlight;
+  outline-offset: 3px;
+}
+
+.firefox-host-access__status {
+  min-height: 20px;
+  margin: 12px 0 0;
+}

--- a/extension/codex-sidepanel/firefox-host-access.js
+++ b/extension/codex-sidepanel/firefox-host-access.js
@@ -1,0 +1,93 @@
+export const REQUIRED_HOST_ACCESS = Object.freeze({ origins: ["<all_urls>"] });
+
+export async function hasFirefoxHostAccess(extension) {
+  if (typeof extension.permissions?.contains !== "function") {
+    return true;
+  }
+  return extension.permissions.contains(REQUIRED_HOST_ACCESS);
+}
+
+function appendTextElement(document, parent, tagName, className, text) {
+  const element = document.createElement(tagName);
+  element.className = className;
+  element.textContent = text;
+  parent.append(element);
+  return element;
+}
+
+export function renderFirefoxHostAccessPrompt({ extension, root, reload }) {
+  const document = root.ownerDocument;
+  root.replaceChildren();
+
+  const main = document.createElement("main");
+  main.className = "firefox-host-access";
+  const card = document.createElement("section");
+  card.className = "firefox-host-access__card";
+  appendTextElement(document, card, "div", "firefox-host-access__icon", "🦊");
+  appendTextElement(document, card, "h1", "firefox-host-access__title", "Allow website access");
+  appendTextElement(
+    document,
+    card,
+    "p",
+    "firefox-host-access__copy",
+    "Codex needs Firefox permission to read and interact with pages after navigation or when a new tab opens.",
+  );
+  appendTextElement(
+    document,
+    card,
+    "p",
+    "firefox-host-access__copy firefox-host-access__copy--muted",
+    "Firefox lets you revoke this at any time from Add-ons and themes → Permissions and data.",
+  );
+
+  const button = appendTextElement(
+    document,
+    card,
+    "button",
+    "firefox-host-access__button",
+    "Allow all websites",
+  );
+  button.type = "button";
+  const status = appendTextElement(document, card, "p", "firefox-host-access__status", "");
+  status.setAttribute("role", "status");
+  status.setAttribute("aria-live", "polite");
+
+  button.addEventListener("click", async () => {
+    button.disabled = true;
+    status.textContent = "Waiting for Firefox…";
+    try {
+      // Keep this request as the first asynchronous action in the click handler:
+      // Firefox requires permissions.request() to be triggered by a user action.
+      const accepted = await extension.permissions.request(REQUIRED_HOST_ACCESS);
+      const granted = accepted && await hasFirefoxHostAccess(extension);
+      if (granted) {
+        status.textContent = "Access granted. Reloading Codex…";
+        reload();
+        return;
+      }
+      status.textContent = "Access was not granted. Choose Allow all websites to try again.";
+    } catch (error) {
+      status.textContent = `Firefox could not grant access: ${error instanceof Error ? error.message : String(error)}`;
+    } finally {
+      button.disabled = false;
+    }
+  });
+
+  main.append(card);
+  root.append(main);
+}
+
+export async function ensureFirefoxHostAccess({
+  extension,
+  root = globalThis.document?.querySelector("#root"),
+  reload = () => globalThis.location.reload(),
+}) {
+  if (await hasFirefoxHostAccess(extension)) {
+    return true;
+  }
+  if (root == null) {
+    throw new Error("Codex side panel root not found while requesting Firefox website access.");
+  }
+  renderFirefoxHostAccessPrompt({ extension, root, reload });
+  return false;
+}

--- a/extension/codex-sidepanel/firefox-sidebar-bootstrap.js
+++ b/extension/codex-sidepanel/firefox-sidebar-bootstrap.js
@@ -1,6 +1,11 @@
-const extension = globalThis.browser ?? globalThis.chrome;
+import { ensureFirefoxHostAccess } from "./firefox-host-access.js";
 
-if (/Firefox\//.test(navigator.userAgent)) {
+const extension = globalThis.browser ?? globalThis.chrome;
+const isFirefox = /Firefox\//.test(navigator.userAgent);
+
+if (isFirefox && !await ensureFirefoxHostAccess({ extension })) {
+  // The permission prompt owns the sidebar until Firefox grants website access.
+} else if (isFirefox) {
   try {
     const windowId = (await extension.windows.getCurrent()).id;
     const isNativeSidebar =
@@ -16,6 +21,7 @@ if (/Firefox\//.test(navigator.userAgent)) {
     // Let the upstream surface render its normal recovery state if Firefox
     // cannot identify or acknowledge the native sidebar window.
   }
+  await import("./assets/chrome-extension-sidepanel-Bf7FJEU3.js");
+} else {
+  await import("./assets/chrome-extension-sidepanel-Bf7FJEU3.js");
 }
-
-await import("./assets/chrome-extension-sidepanel-Bf7FJEU3.js");

--- a/extension/codex-sidepanel/index.html
+++ b/extension/codex-sidepanel/index.html
@@ -11,6 +11,7 @@
     <title>ChatGPT</title>
     <script src="./firefox-focus-compat.js"></script>
     <script type="module" crossorigin src="./firefox-sidebar-bootstrap.js"></script>
+    <link rel="stylesheet" href="./firefox-host-access.css">
     <link rel="modulepreload" crossorigin href="./assets/rolldown-runtime-C_JxhDyB.js">
     <link rel="modulepreload" crossorigin href="./assets/jsx-runtime-CNO-vQvX.js">
     <link rel="modulepreload" crossorigin href="./assets/preload-helper-DYl5dUZ5.js">

--- a/extension/firefox-compat.js
+++ b/extension/firefox-compat.js
@@ -7,6 +7,7 @@
   }
 
   const OFFICIAL_CHROME_EXTENSION_ID = "hehggadaopoacecdllhhajmbjkdcmajg";
+  const FIREFOX_BRIDGE_DISPLAY_NAME = "Codex Firefox Bridge (Firefox/Zen)";
   const BINDING_MESSAGE_SOURCE = "chatgpt-firefox-cdp";
 
   const nativeFetch = typeof globalThis.fetch === "function"
@@ -201,9 +202,13 @@
                 ...message,
                 result: {
                   ...message.result,
-                  name: "Firefox",
+                  name: FIREFOX_BRIDGE_DISPLAY_NAME,
                   metadata: {
                     ...message.result.metadata,
+                    actualBrowserFamily: "firefox",
+                    bridgeName: "codex-firefox-bridge",
+                    bridgeVersion: firefox.runtime.getManifest().version,
+                    compatibilityFamily: "chrome",
                     extensionId: OFFICIAL_CHROME_EXTENSION_ID,
                     geckoExtensionId: firefox.runtime.id,
                   },
@@ -566,6 +571,14 @@
     if (firefox.scripting?.executeScript == null) {
       throw new Error(
         "Firefox page automation requires scripting.executeScript support.",
+      );
+    }
+    if (
+      typeof firefox.permissions?.contains === "function"
+      && !await firefox.permissions.contains({ origins: ["<all_urls>"] })
+    ) {
+      throw new Error(
+        "Firefox website access is disabled. Reopen the Codex sidebar, choose Allow all websites, and then retry this browser action.",
       );
     }
   }
@@ -1079,7 +1092,28 @@
     if (format === "jpeg" && Number.isInteger(params.quality)) {
       options.quality = Math.max(0, Math.min(100, params.quality));
     }
-    const dataUrl = await firefox.tabs.captureTab(tabId, options);
+    let dataUrl;
+    if (typeof firefox.tabs.captureTab === "function") {
+      dataUrl = await firefox.tabs.captureTab(tabId, options);
+    } else if (typeof firefox.tabs.captureVisibleTab === "function") {
+      const targetTab = await firefox.tabs.get(tabId);
+      const [previousActiveTab] = await firefox.tabs.query({ active: true, windowId: targetTab.windowId });
+      const shouldRestore = !targetTab.active && previousActiveTab?.id != null && previousActiveTab.id !== tabId;
+      if (!targetTab.active) {
+        await firefox.tabs.update(tabId, { active: true });
+      }
+      try {
+        dataUrl = await firefox.tabs.captureVisibleTab(targetTab.windowId, options);
+      } finally {
+        if (shouldRestore) {
+          await firefox.tabs.update(previousActiveTab.id, { active: true }).catch(() => {});
+        }
+      }
+    } else {
+      throw new Error(
+        "Firefox screenshot capture requires tabs.captureTab or tabs.captureVisibleTab support.",
+      );
+    }
     const comma = dataUrl.indexOf(",");
     return { data: comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl };
   }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Codex Computer Use for Zen & Fox",
   "description": "Bring Codex computer use and its signed-in sidebar to Firefox and Zen Browser.",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "icons": {
     "16": "images/firefox-zen-icon16.png",
     "32": "images/firefox-zen-icon32.png",

--- a/native-host/Cargo.lock
+++ b/native-host/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "codex-firefox-bridge"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "base64",
  "regex",

--- a/native-host/Cargo.toml
+++ b/native-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-firefox-bridge"
-version = "1.4.4"
+version = "1.4.5"
 edition = "2021"
 description = "Firefox native-messaging bridge for the installed OpenAI Codex extension host"
 license = "UNLICENSED"

--- a/native-host/src/main.rs
+++ b/native-host/src/main.rs
@@ -421,7 +421,10 @@ fn rewrite_firefox_extension_id(value: &mut Value) -> bool {
             }
         }
         Value::Object(object) => {
-            for child in object.values_mut() {
+            for (key, child) in object.iter_mut() {
+                if key == "geckoExtensionId" {
+                    continue;
+                }
                 changed |= rewrite_firefox_extension_id(child);
             }
         }
@@ -881,6 +884,30 @@ mod tests {
         assert_eq!(
             rewritten["params"]["constraints"]["extensionId"],
             OFFICIAL_CHROME_EXTENSION_ID
+        );
+    }
+
+    #[test]
+    fn preserves_the_real_gecko_id_in_bridge_metadata() {
+        let payload = serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "id": "bridge-info",
+            "result": {
+                "metadata": {
+                    "extensionId": FIREFOX_EXTENSION_ID,
+                    "geckoExtensionId": FIREFOX_EXTENSION_ID
+                }
+            }
+        }))
+        .unwrap();
+        let rewritten: Value = serde_json::from_slice(&rewrite_native_request(payload)).unwrap();
+        assert_eq!(
+            rewritten["result"]["metadata"]["extensionId"],
+            OFFICIAL_CHROME_EXTENSION_ID
+        );
+        assert_eq!(
+            rewritten["result"]["metadata"]["geckoExtensionId"],
+            FIREFOX_EXTENSION_ID
         );
     }
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-firefox-bridge",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Install and manage the Codex native-messaging bridge for Firefox and Zen",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "codex-computer-use-firefox-zen",
   "private": true,
-  "version": "1.4.4",
+  "type": "module",
+  "version": "1.4.5",
   "description": "Codex computer-use compatibility port for Firefox and Zen Browser",
   "scripts": {
     "check": "node scripts/check-version.mjs && node scripts/verify-extension.mjs",
     "version:set": "node scripts/set-version.mjs",
-    "test": "npm run check && node tests/test-sidepanel-focus-compat.mjs && node tests/test-sidepanel-bootstrap.mjs && node tests/test-chatgpt-feature-parity.mjs && node tests/test-firefox-compat.mjs && node tests/test-editing-assets.mjs && node tests/test-native-host.mjs",
+    "test": "npm run check && node tests/test-sidepanel-focus-compat.mjs && node tests/test-sidepanel-host-access.mjs && node tests/test-sidepanel-bootstrap.mjs && node tests/test-chatgpt-feature-parity.mjs && node tests/test-firefox-compat.mjs && node tests/test-editing-assets.mjs && node tests/test-native-host.mjs",
     "package": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-extension.ps1"
   }
 }

--- a/tests/test-firefox-compat.mjs
+++ b/tests/test-firefox-compat.mjs
@@ -31,10 +31,15 @@ const executedFaviconTargets = [];
 const createdTabs = [];
 const fetchedUrls = [];
 const storedValues = {};
+let allWebsiteAccessGranted = true;
+let captureVisibleTabCalls = [];
+let targetTabActive = true;
+const tabUpdateCalls = [];
+const nativePostedMessages = [];
 const nativePort = {
   onMessage: new EventMock(),
   onDisconnect: new EventMock(),
-  postMessage() {},
+  postMessage(message) { nativePostedMessages.push(message); },
   disconnect() {},
 };
 const browser = {
@@ -49,7 +54,13 @@ const browser = {
     async setBadgeBackgroundColor() {},
     async setBadgeText() {},
   },
-  permissions: { async request() { return true; } },
+  permissions: {
+    async contains(details) {
+      assert.equal(JSON.stringify(details), JSON.stringify({ origins: ["<all_urls>"] }));
+      return allWebsiteAccessGranted;
+    },
+    async request() { return true; },
+  },
   sidebarAction: { async open() {}, async close() {} },
   storage: {
     local: {
@@ -63,11 +74,24 @@ const browser = {
   },
   tabs: {
     onUpdated: new EventMock(), onRemoved: new EventMock(),
-    async query() { return [{ id: 1, windowId: 10, index: 0, url: "https://top.test/", title: "Top", active: true, favIconUrl: "https://top.test/favicon.ico" }]; },
-    async get() { return { id: 1, windowId: 10, index: 0, url: "https://top.test/", title: "Top", active: true, favIconUrl: "https://top.test/favicon.ico" }; },
+    async query(queryInfo) {
+      if (queryInfo?.active && !targetTabActive) {
+        return [{ id: 2, windowId: 10, index: 1, url: "https://other.test/", title: "Other", active: true }];
+      }
+      return [{ id: 1, windowId: 10, index: 0, url: "https://top.test/", title: "Top", active: targetTabActive, favIconUrl: "https://top.test/favicon.ico" }];
+    },
+    async get() { return { id: 1, windowId: 10, index: 0, url: "https://top.test/", title: "Top", active: targetTabActive, favIconUrl: "https://top.test/favicon.ico" }; },
     async create(details) { createdTabs.push(details); },
-    async update() {}, async remove() {}, async reload() {}, async setZoom() {},
+    async update(tabId, details) {
+      tabUpdateCalls.push({ tabId, details });
+      if (details?.active) targetTabActive = tabId === 1;
+    },
+    async remove() {}, async reload() {}, async setZoom() {},
     async captureTab() { return "data:image/png;base64,dGVzdA=="; },
+    async captureVisibleTab(windowId, options) {
+      captureVisibleTabCalls.push({ windowId, options });
+      return "data:image/png;base64,ZmFsbGJhY2s=";
+    },
   },
   windows: { async get() { return { id: 10, state: "normal", width: 1200, height: 800, left: 0, top: 0 }; }, async update() { return {}; } },
   webNavigation: {
@@ -140,6 +164,26 @@ assert.equal(
   "function",
   "The current OpenAI background requires a Firefox-safe toolbar settings event.",
 );
+
+const identityPort = context.chrome.runtime.connectNative("com.openai.codexextension");
+identityPort.onMessage.addListener(() => {});
+nativePort.onMessage.emit({ id: "bridge-info", method: "getInfo" });
+identityPort.postMessage({
+  id: "bridge-info",
+  result: {
+    name: "Chrome",
+    metadata: { extensionInstanceId: "test-instance" },
+  },
+});
+const bridgeIdentity = nativePostedMessages.at(-1).result;
+assert.equal(bridgeIdentity.name, "Codex Firefox Bridge (Firefox/Zen)");
+assert.equal(bridgeIdentity.metadata.actualBrowserFamily, "firefox");
+assert.equal(bridgeIdentity.metadata.bridgeName, "codex-firefox-bridge");
+assert.equal(bridgeIdentity.metadata.bridgeVersion, "test");
+assert.equal(bridgeIdentity.metadata.compatibilityFamily, "chrome");
+assert.equal(bridgeIdentity.metadata.extensionId, "hehggadaopoacecdllhhajmbjkdcmajg");
+assert.equal(bridgeIdentity.metadata.geckoExtensionId, "codex-computer-use-firefox-zen@sunkenintime");
+assert.equal(bridgeIdentity.metadata.extensionInstanceId, "test-instance");
 
 const faviconResponse = await context.fetch("moz-extension://test/_favicon/?pageUrl=https%3A%2F%2Ftop.test%2F&size=32");
 assert.equal(faviconResponse.ok, true);
@@ -229,7 +273,35 @@ assert.equal(createdTabs[0].url, "moz-extension://test/companion-required.html")
 
 const events = [];
 compat.debugger.onEvent.addListener((sourceInfo, method, params) => events.push({ sourceInfo, method, params }));
+allWebsiteAccessGranted = false;
+await assert.rejects(
+  compat.debugger.attach({ tabId: 1 }),
+  /Firefox website access is disabled/u,
+  "Revoked Firefox host access must fail before the raw scripting error.",
+);
+allWebsiteAccessGranted = true;
 await compat.debugger.attach({ tabId: 1 });
+
+const captureTab = browser.tabs.captureTab;
+browser.tabs.captureTab = undefined;
+targetTabActive = false;
+tabUpdateCalls.length = 0;
+const fallbackScreenshot = await compat.debugger.sendCommand({ tabId: 1 }, "Page.captureScreenshot", { format: "png" });
+browser.tabs.captureTab = captureTab;
+assert.equal(fallbackScreenshot.data, "ZmFsbGJhY2s=");
+assert.equal(
+  JSON.stringify(captureVisibleTabCalls),
+  JSON.stringify([{ windowId: 10, options: { format: "png" } }]),
+);
+assert.equal(
+  JSON.stringify(tabUpdateCalls),
+  JSON.stringify([
+    { tabId: 1, details: { active: true } },
+    { tabId: 2, details: { active: true } },
+  ]),
+  "Visible-tab fallback must restore the tab that was active before capture.",
+);
+targetTabActive = true;
 
 const tree = await compat.debugger.sendCommand({ tabId: 1 }, "Page.getFrameTree", {});
 assert.equal(tree.frameTree.frame.id, "firefox-frame-1");
@@ -289,4 +361,4 @@ const unpausedResponse = beforeRequest({ requestId: "req-3", tabId: 1, frameId: 
 assert.equal(JSON.stringify(unpausedResponse), "{}", "Empty Fetch patterns must clear interception instead of pausing every request.");
 assert.equal(events.filter((event) => event.method === "Fetch.requestPaused").length, pauseCount);
 
-console.log(JSON.stringify({ ok: true, toolbarSettings: true, nativeSidebarTracking: true, frameTree: true, childExecution: true, keyboardSyntax: true, liveNetworkEvents: true, responseBody: true, fetchInterception: true, fetchEmptyPatternClear: true }, null, 2));
+console.log(JSON.stringify({ ok: true, bridgeIdentity: true, toolbarSettings: true, nativeSidebarTracking: true, hostAccessPreflight: true, screenshotFallback: true, frameTree: true, childExecution: true, keyboardSyntax: true, liveNetworkEvents: true, responseBody: true, fetchInterception: true, fetchEmptyPatternClear: true }, null, 2));

--- a/tests/test-sidepanel-bootstrap.mjs
+++ b/tests/test-sidepanel-bootstrap.mjs
@@ -9,8 +9,11 @@ assert.doesNotMatch(html, /src="\.\/assets\/chrome-extension-sidepanel-[^"]+\.js
 
 const handshakeIndex = bootstrap.indexOf("await extension.runtime.sendMessage");
 const upstreamImportIndex = bootstrap.indexOf('await import("./assets/chrome-extension-sidepanel-Bf7FJEU3.js")');
+const permissionGateIndex = bootstrap.indexOf("await ensureFirefoxHostAccess");
+assert.ok(permissionGateIndex >= 0, "Bootstrap must check Firefox host access.");
+assert.ok(handshakeIndex > permissionGateIndex, "Firefox host access must be granted before the sidebar handshake.");
 assert.ok(handshakeIndex >= 0, "Bootstrap must await the Firefox sidebar readiness handshake.");
 assert.ok(upstreamImportIndex > handshakeIndex, "Upstream sidebar must load only after the readiness handshake.");
 assert.match(bootstrap, /getViews\?\.\(\{ type: "sidebar" \}\)\?\.includes\(window\)/u);
 
-console.log(JSON.stringify({ ok: true, nativeSidebarIdentity: true, sidebarReadyBeforeUpstreamBoot: true }, null, 2));
+console.log(JSON.stringify({ ok: true, hostAccessBeforeSidebarBoot: true, nativeSidebarIdentity: true, sidebarReadyBeforeUpstreamBoot: true }, null, 2));

--- a/tests/test-sidepanel-host-access.mjs
+++ b/tests/test-sidepanel-host-access.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import {
+  REQUIRED_HOST_ACCESS,
+  ensureFirefoxHostAccess,
+} from "../extension/codex-sidepanel/firefox-host-access.js";
+
+class ElementMock {
+  constructor(ownerDocument, tagName) {
+    this.ownerDocument = ownerDocument;
+    this.tagName = tagName;
+    this.children = [];
+    this.listeners = new Map();
+    this.textContent = "";
+  }
+  append(...children) { this.children.push(...children); }
+  replaceChildren(...children) { this.children = [...children]; }
+  setAttribute(name, value) { this[name] = value; }
+  addEventListener(type, listener) { this.listeners.set(type, listener); }
+  async click() { await this.listeners.get("click")?.(); }
+}
+
+function createDom() {
+  const document = { createElement: (tagName) => new ElementMock(document, tagName) };
+  const root = new ElementMock(document, "div");
+  return { document, root };
+}
+
+function descendants(element) {
+  return [element, ...element.children.flatMap(descendants)];
+}
+
+{
+  const { root } = createDom();
+  const extension = { permissions: { async contains(details) {
+    assert.deepEqual(details, REQUIRED_HOST_ACCESS);
+    return true;
+  } } };
+  assert.equal(await ensureFirefoxHostAccess({ extension, root }), true);
+  assert.equal(root.children.length, 0, "Granted access must not replace the sidebar app.");
+}
+
+{
+  const { root } = createDom();
+  let granted = false;
+  let reloads = 0;
+  const extension = { permissions: {
+    async contains() { return granted; },
+    async request(details) {
+      assert.deepEqual(details, REQUIRED_HOST_ACCESS);
+      granted = true;
+      return true;
+    },
+  } };
+  assert.equal(await ensureFirefoxHostAccess({ extension, root, reload: () => { reloads += 1; } }), false);
+  const nodes = descendants(root);
+  const button = nodes.find((node) => node.tagName === "button");
+  assert.equal(button?.textContent, "Allow all websites");
+  await button.click();
+  assert.equal(reloads, 1, "Granting host access must reload the sidebar app.");
+}
+
+{
+  const { root } = createDom();
+  let reloads = 0;
+  const extension = { permissions: {
+    async contains() { return false; },
+    async request() { return false; },
+  } };
+  assert.equal(await ensureFirefoxHostAccess({ extension, root, reload: () => { reloads += 1; } }), false);
+  const nodes = descendants(root);
+  const button = nodes.find((node) => node.tagName === "button");
+  await button.click();
+  const status = nodes.find((node) => node.className === "firefox-host-access__status");
+  assert.match(status.textContent, /not granted/u);
+  assert.equal(reloads, 0, "Refusing host access must leave the permission screen visible.");
+}
+
+console.log(JSON.stringify({ ok: true, grantedBypass: true, userGrant: true, refusalRecovery: true }, null, 2));

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.4",
+  "version": "1.4.5",
   "upstream_extension_version": "1.2.27236.6274",
   "native_host_name": "com.openai.codexextension",
   "gecko_extension_id": "codex-computer-use-firefox-zen@sunkenintime"


### PR DESCRIPTION
## What changed

- add a Firefox host-access preflight and actionable recovery when all-sites access is missing or revoked
- fall back to `tabs.captureVisibleTab` when Zen does not expose `tabs.captureTab`, while restoring the previously active tab
- advertise `Codex Firefox Bridge (Firefox/Zen)` plus actual-versus-compatibility browser metadata through the existing discovery protocol
- preserve the real Gecko extension ID in informational bridge metadata
- bump the extension, Rust companion, and npm installer together to 1.4.5

## Why

A live Expedia computer-use run lost page access after navigation because Firefox's all-sites permission was disabled. The same run also exposed a separate Zen screenshot incompatibility. Chrome-oriented troubleshooting then obscured the real browser identity because the bridge must retain a Chrome-compatible transport family.

## Impact

Firefox/Zen users now receive a clear, user-triggered permission surface before automation begins, screenshots work on Zen builds without `captureTab`, and Codex can see that the selected external browser is the Codex Firefox bridge without changing the upstream compatibility contract.

## Validation

- `cargo fmt --manifest-path native-host/Cargo.toml -- --check`
- `cargo test --locked --manifest-path native-host/Cargo.toml` (10 passed)
- `npm test`
- `npm test --prefix npm` (4 passed)
- `npm pack ./npm --dry-run --json`
- `npx --yes web-ext lint --source-dir extension --no-input` (0 errors)
- isolated live Zen verification for DOM reads, cross-origin navigation, screenshot fallback, and browser discovery metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Firefox website-access permission checks with a clear prompt, approval flow, and recovery guidance.
  * Improved Firefox and Zen compatibility metadata and discovery information.
  * Added screenshot capture fallback support for broader browser compatibility.
* **Bug Fixes**
  * Preserved accurate Firefox extension identity information.
  * Restored the previously active tab after fallback screenshot capture.
* **Documentation**
  * Updated setup instructions for website access and script execution permissions.
* **Chores**
  * Updated the extension, native bridge, and package versions to 1.4.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->