### PR TITLE
Harden Windows bridge setup recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This project follows semantic versioning. The Firefox add-on and native companio
 always share one version and are released from a matching `vMAJOR.MINOR.PATCH`
 Git tag.
 
+## Unreleased
+
+- Fixed Windows companion removal when Firefox or Zen left an installed bridge
+  process running after the browser exited.
+- Retried transient network and GitHub server failures while downloading npm
+  installer assets.
+
 ## 1.4.5 - 2026-08-11
 
 - Advertised an explicit `Codex Firefox Bridge (Firefox/Zen)` browser name and

--- a/npm/cli.mjs
+++ b/npm/cli.mjs
@@ -118,6 +118,12 @@ function doctor() {
   console.log(diagnostic);
 }
 
+/**
+ * Stops versioned bridge processes running from the validated install directory.
+ *
+ * @param {string} directory Validated bridge installation directory.
+ * @returns {void}
+ */
 function stopWindowsBridgeProcesses(directory) {
   let output;
   try {

--- a/npm/cli.mjs
+++ b/npm/cli.mjs
@@ -10,8 +10,10 @@ import {
   HOST_NAME,
   assertSafeInstallDirectory,
   checksumAsset,
+  downloadWithRetry,
   expectedChecksum,
   installLocations,
+  isInstalledBridgeBinary,
   nativeManifest,
   platformAsset,
   readInstalledManifest,
@@ -24,17 +26,6 @@ const packageJson = JSON.parse(
 );
 const version = packageJson.version;
 const command = process.argv[2] ?? "help";
-
-async function download(url) {
-  const response = await fetch(url, {
-    headers: { "user-agent": `codex-firefox-bridge/${version}` },
-    redirect: "follow"
-  });
-  if (!response.ok) {
-    throw new Error(`Download failed (${response.status}): ${url}`);
-  }
-  return Buffer.from(await response.arrayBuffer());
-}
 
 function writeManifest(manifestPath, binaryPath) {
   fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
@@ -70,8 +61,12 @@ async function install() {
   } else {
     const base = releaseBase(version);
     const [downloadedBinary, checksums] = await Promise.all([
-      download(`${base}/${assetName}`),
-      download(`${base}/${checksumAsset(version)}`)
+      downloadWithRetry(`${base}/${assetName}`, {
+        headers: { "user-agent": `codex-firefox-bridge/${version}` }
+      }),
+      downloadWithRetry(`${base}/${checksumAsset(version)}`, {
+        headers: { "user-agent": `codex-firefox-bridge/${version}` }
+      })
     ]);
     const expected = expectedChecksum(checksums.toString("utf8"), assetName);
     const actual = crypto.createHash("sha256").update(downloadedBinary).digest("hex");
@@ -123,6 +118,46 @@ function doctor() {
   console.log(diagnostic);
 }
 
+function stopWindowsBridgeProcesses(directory) {
+  let output;
+  try {
+    output = execFileSync(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "Get-CimInstance Win32_Process | " +
+          "Where-Object { $_.Name -like 'codex-firefox-bridge-*.exe' } | " +
+          "Select-Object ProcessId,ExecutablePath | ConvertTo-Json -Compress"
+      ],
+      { encoding: "utf8", timeout: 15_000 }
+    ).trim();
+  } catch {
+    // Removing an idle installation does not require process discovery. If a
+    // bridge is still active, the final directory removal reports the failure.
+    return;
+  }
+  if (!output) {
+    return;
+  }
+  const parsed = JSON.parse(output);
+  const processes = Array.isArray(parsed) ? parsed : [parsed];
+  for (const processInfo of processes) {
+    if (
+      !Number.isInteger(processInfo.ProcessId) ||
+      !isInstalledBridgeBinary(processInfo.ExecutablePath, directory, "win32")
+    ) {
+      continue;
+    }
+    execFileSync(
+      "taskkill",
+      ["/PID", String(processInfo.ProcessId), "/T", "/F"],
+      { stdio: "ignore", timeout: 15_000 }
+    );
+  }
+}
+
 function uninstall() {
   const locations = installLocations();
   const directory = assertSafeInstallDirectory(locations.directory);
@@ -144,6 +179,9 @@ function uninstall() {
         `Refusing to remove an unfamiliar native-host manifest: ${error.message}`
       );
     }
+  }
+  if (process.platform === "win32") {
+    stopWindowsBridgeProcesses(directory);
   }
   fs.rmSync(directory, { recursive: true, force: true });
   console.log("Removed Codex Firefox Bridge.");

--- a/npm/cli.mjs
+++ b/npm/cli.mjs
@@ -150,11 +150,16 @@ function stopWindowsBridgeProcesses(directory) {
     ) {
       continue;
     }
-    execFileSync(
-      "taskkill",
-      ["/PID", String(processInfo.ProcessId), "/T", "/F"],
-      { stdio: "ignore", timeout: 15_000 }
-    );
+    try {
+      execFileSync(
+        "taskkill",
+        ["/PID", String(processInfo.ProcessId), "/T", "/F"],
+        { stdio: "ignore", timeout: 15_000 }
+      );
+    } catch {
+      // The process may have exited after discovery. Directory removal below
+      // reports any process that still holds an installation file.
+    }
   }
 }
 

--- a/npm/lib.mjs
+++ b/npm/lib.mjs
@@ -37,6 +37,13 @@ export function releaseBase(version) {
   ).replace(/\/$/u, "");
 }
 
+/**
+ * Downloads a release asset, retrying transient HTTP and network failures.
+ *
+ * @param {string} url Release asset URL.
+ * @param {object} [options] Retry and dependency-injection options.
+ * @returns {Promise<Buffer>} Downloaded asset bytes.
+ */
 export async function downloadWithRetry(
   url,
   {
@@ -149,6 +156,14 @@ export function assertSafeInstallDirectory(directory, platform = process.platfor
   return resolved;
 }
 
+/**
+ * Checks whether a process executable is a versioned bridge in the install directory.
+ *
+ * @param {string} executablePath Candidate executable path.
+ * @param {string} installDirectory Validated bridge installation directory.
+ * @param {string} [platform] Path semantics to use.
+ * @returns {boolean} Whether the executable belongs to this installation.
+ */
 export function isInstalledBridgeBinary(
   executablePath,
   installDirectory,

--- a/npm/lib.mjs
+++ b/npm/lib.mjs
@@ -37,6 +37,46 @@ export function releaseBase(version) {
   ).replace(/\/$/u, "");
 }
 
+export async function downloadWithRetry(
+  url,
+  {
+    attempts = 4,
+    baseDelayMs = 500,
+    fetchImpl = globalThis.fetch,
+    headers = {},
+    sleep = (milliseconds) =>
+      new Promise((resolve) => setTimeout(resolve, milliseconds))
+  } = {}
+) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(url, { headers, redirect: "follow" });
+      if (response.ok) {
+        return Buffer.from(await response.arrayBuffer());
+      }
+      lastError = new Error(`Download failed (${response.status}): ${url}`);
+      lastError.retryable =
+        response.status === 408 ||
+        response.status === 425 ||
+        response.status === 429 ||
+        response.status >= 500;
+      if (!lastError.retryable) {
+        throw lastError;
+      }
+    } catch (error) {
+      lastError = error;
+      if (error.retryable === false) {
+        throw error;
+      }
+    }
+    if (attempt < attempts) {
+      await sleep(baseDelayMs * 2 ** (attempt - 1));
+    }
+  }
+  throw lastError;
+}
+
 export function installLocations(
   platform = process.platform,
   environment = process.env,
@@ -107,6 +147,30 @@ export function assertSafeInstallDirectory(directory, platform = process.platfor
     throw new Error("LOCALAPPDATA is unavailable.");
   }
   return resolved;
+}
+
+export function isInstalledBridgeBinary(
+  executablePath,
+  installDirectory,
+  platform = process.platform
+) {
+  if (!executablePath || !installDirectory) {
+    return false;
+  }
+  const platformPath = platform === "win32" ? path.win32 : path.posix;
+  const resolvedDirectory = platformPath.resolve(installDirectory);
+  const resolvedExecutable = platformPath.resolve(executablePath);
+  const relative = platformPath.relative(resolvedDirectory, resolvedExecutable);
+  if (
+    relative.startsWith("..") ||
+    platformPath.isAbsolute(relative) ||
+    relative.includes(platformPath.sep)
+  ) {
+    return false;
+  }
+  return /^codex-firefox-bridge-\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?\.exe$/iu.test(
+    relative
+  );
 }
 
 export function readInstalledManifest(manifestPath) {

--- a/npm/test/lib.test.mjs
+++ b/npm/test/lib.test.mjs
@@ -88,6 +88,48 @@ test("retries transient release-download failures", async () => {
   assert.equal(calls, 2);
 });
 
+test("retries release downloads after network errors", async () => {
+  let calls = 0;
+  const value = await downloadWithRetry("https://example.test/bridge", {
+    attempts: 3,
+    fetchImpl: async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new TypeError("fetch failed");
+      }
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => Buffer.from("bridge")
+      };
+    },
+    sleep: async () => {}
+  });
+  assert.equal(value.toString("utf8"), "bridge");
+  assert.equal(calls, 2);
+});
+
+test("retries rate-limited release downloads", async () => {
+  let calls = 0;
+  const value = await downloadWithRetry("https://example.test/bridge", {
+    attempts: 3,
+    fetchImpl: async () => {
+      calls += 1;
+      if (calls === 1) {
+        return { ok: false, status: 429 };
+      }
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => Buffer.from("bridge")
+      };
+    },
+    sleep: async () => {}
+  });
+  assert.equal(value.toString("utf8"), "bridge");
+  assert.equal(calls, 2);
+});
+
 test("does not retry permanent release-download failures", async () => {
   let calls = 0;
   await assert.rejects(

--- a/npm/test/lib.test.mjs
+++ b/npm/test/lib.test.mjs
@@ -3,8 +3,10 @@ import path from "node:path";
 import test from "node:test";
 import {
   checksumAsset,
+  downloadWithRetry,
   expectedChecksum,
   installLocations,
+  isInstalledBridgeBinary,
   nativeManifest,
   platformAsset
 } from "../lib.mjs";
@@ -62,5 +64,74 @@ test("uses per-user installation locations", () => {
   assert.equal(
     macos.manifest,
     "/Users/test/Library/Application Support/Mozilla/NativeMessagingHosts/com.openai.codexextension.json"
+  );
+});
+
+test("retries transient release-download failures", async () => {
+  let calls = 0;
+  const value = await downloadWithRetry("https://example.test/bridge", {
+    attempts: 3,
+    fetchImpl: async () => {
+      calls += 1;
+      if (calls === 1) {
+        return { ok: false, status: 503 };
+      }
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => Buffer.from("bridge")
+      };
+    },
+    sleep: async () => {}
+  });
+  assert.equal(value.toString("utf8"), "bridge");
+  assert.equal(calls, 2);
+});
+
+test("does not retry permanent release-download failures", async () => {
+  let calls = 0;
+  await assert.rejects(
+    downloadWithRetry("https://example.test/missing", {
+      attempts: 3,
+      fetchImpl: async () => {
+        calls += 1;
+        return { ok: false, status: 404 };
+      },
+      sleep: async () => {}
+    }),
+    /Download failed \(404\)/u
+  );
+  assert.equal(calls, 1);
+});
+
+test("only identifies versioned bridge processes inside the install directory", () => {
+  const directory = "C:\\Users\\test\\AppData\\Local\\Codex Firefox Bridge";
+  assert.equal(
+    isInstalledBridgeBinary(
+      `${directory}\\codex-firefox-bridge-1.4.1.exe`,
+      directory,
+      "win32"
+    ),
+    true
+  );
+  assert.equal(
+    isInstalledBridgeBinary(
+      `${directory}\\codex-firefox-bridge-1.4.6-beta.1.exe`,
+      directory,
+      "win32"
+    ),
+    true
+  );
+  assert.equal(
+    isInstalledBridgeBinary(
+      "C:\\Temp\\codex-firefox-bridge-1.4.1.exe",
+      directory,
+      "win32"
+    ),
+    false
+  );
+  assert.equal(
+    isInstalledBridgeBinary(`${directory}\\unrelated.exe`, directory, "win32"),
+    false
   );
 });


### PR DESCRIPTION
## Summary

- retry transient network, rate-limit, and GitHub server failures while downloading npm installer assets
- stop only versioned bridge processes running from the validated per-user install directory before Windows uninstallation removes it
- add regression coverage for retry behavior, permanent download failures, and process-path scoping
- document both setup fixes in the changelog

## Root cause

A clean-install rehearsal exposed two setup failures. Zen could leave the native-messaging bridge process alive after the add-on and browser were closed, causing `codex-firefox-bridge uninstall` to fail with `EPERM` when removing its install directory. Separately, release downloads were single-attempt operations, so a transient GitHub 503 aborted installation immediately.

## Impact

Windows users can now remove or replace a bridge left running by Firefox/Zen, without terminating similarly named binaries outside the bridge install directory. Installer downloads tolerate short-lived network and GitHub failures while still failing immediately for permanent client errors.

## Validation

- `npm test`
- `npm test` and `npm pack --dry-run` from `npm/`
- live Windows reproduction: patched uninstall removed the orphaned 1.4.1 process, install directory, and native-host registration
- live clean install: patched downloader recovered from an observed GitHub 503, installed 1.4.5, and `doctor` reported `Registration: OK` with `bridge-version=1.4.5`
- `web-ext lint --source-dir extension --no-input` (0 errors, existing inherited warnings only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows uninstallation by stopping lingering browser bridge processes before removing installation files.
  * Added automatic retries for temporary network and GitHub download failures during installation.
  * Prevented retries for permanent download errors.
* **Tests**
  * Added coverage for download retry behavior and safe detection of installed Windows bridge binaries.
* **Documentation**
  * Updated the changelog with the latest Windows cleanup and installer reliability fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->