### PR TITLE
Improve README and surface bridge version mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,140 +1,155 @@
-# Codex Computer Use for Firefox and Zen Browser
+<p align="center">
+  <img src="extension/images/firefox-zen-logo.png" alt="Codex Computer Use for Firefox and Zen Browser" width="180">
+</p>
 
-This is a Firefox-compatible port of OpenAI's official browser extension (`hehggadaopoacecdllhhajmbjkdcmajg`), based on packaged extension version `1.2.27236.6274` (build `ad34341c30168f421705cd15f1633ebe6cea7849`). Zen Browser is supported as a Firefox-based browser and is the primary live-test target.
+<h1 align="center">Codex Computer Use for Firefox & Zen</h1>
 
-This is an independent compatibility project. It is not an official OpenAI, Mozilla, or Zen Browser release and is not endorsed by those organizations. You need an existing ChatGPT/Codex installation and account; this repository does not include or bypass account access.
+<p align="center">
+  <strong>Bring the signed-in Codex sidebar and browser control to Firefox-family browsers.</strong>
+</p>
 
-The original OpenAI sidebar and background application are retained. The compatibility layer adds:
+<p align="center">
+  <a href="https://addons.mozilla.org/firefox/addon/codex-computer-use-for-zen/"><img alt="Firefox Add-on" src="https://img.shields.io/amo/v/codex-computer-use-for-zen?logo=firefoxbrowser&amp;label=Firefox%20Add-on"></a>
+  <a href="https://www.npmjs.com/package/codex-firefox-bridge"><img alt="npm bridge" src="https://img.shields.io/npm/v/codex-firefox-bridge?logo=npm&amp;label=native%20bridge"></a>
+  <a href="https://github.com/SunkenInTime/codex-computer-use-firefox-zen/releases/latest"><img alt="Latest GitHub release" src="https://img.shields.io/github/v/release/SunkenInTime/codex-computer-use-firefox-zen?logo=github"></a>
+</p>
 
-- Firefox `sidebar_action` support in place of Chrome `sidePanel`;
-- a persistent Firefox background page in place of a Manifest V3 service worker;
-- explicit `Codex Firefox Bridge (Firefox and Zen Browser)` discovery metadata while retaining
-  the official host's Chrome-compatible transport family;
-- translation of the `chrome.debugger`/CDP operations used by OpenAI's browser-control client into Firefox tab, cookie, screenshot, scripting, DOM, and input APIs;
-- a native-messaging adapter that securely relays to the locally installed official OpenAI extension host;
-- local-file transfer for controlled file inputs;
-- exact device-viewport emulation, restored after each run;
-- HTML5 and pointer drag-and-drop, page-resource discovery, and resource-body transfer;
-- frame-scoped DOM, input, clipboard, and CDP translation across nested cross-origin iframes;
-- translated `Network` lifecycle/body capture, `Fetch` interception, emulation, and JavaScript-dialog handling.
+<p align="center">
+  <a href="https://addons.mozilla.org/firefox/addon/codex-computer-use-for-zen/"><strong>Install from Firefox Add-ons →</strong></a>
+</p>
 
-## Verified parity
+Codex Computer Use for Firefox translates the browser-control operations used by OpenAI's extension into Firefox APIs while preserving the familiar signed-in sidebar. Zen Browser is the primary live-test target, and Firefox is supported from the same signed add-on.
+
+This is an independent compatibility project—not an official OpenAI, Mozilla, or Zen Browser release. It requires an existing ChatGPT/Codex account and installation; it does not provide or bypass account access.
+
+## Why use it?
+
+- **Work where you already browse.** Keep Codex beside your tabs in Firefox or Zen Browser.
+- **Use real browser control.** Codex can inspect pages, click, type, scroll, navigate, upload files, take screenshots, and work across frames.
+- **Keep the original experience.** The packaged OpenAI sidebar and background application remain intact; this project changes the compatibility and transport layers.
+- **Recover clearly.** Missing companions, revoked site access, and bridge/extension version mismatches surface as actionable setup UI instead of silent connection failures.
+
+## Install in three steps
+
+### 1. Install the signed extension
+
+[Install Codex Computer Use for Firefox from Mozilla Add-ons](https://addons.mozilla.org/firefox/addon/codex-computer-use-for-zen/), then pin or open **Codex for Firefox and Zen Browser** from the browser toolbar.
+
+### 2. Install the matching native bridge
+
+The add-on opens a one-time setup page with signed Windows and macOS installers. You can also install the same per-user bridge from npm:
+
+```sh
+npx --yes codex-firefox-bridge@latest install
+```
+
+The bridge remains installed after `npx` exits. Check it at any time with:
+
+```sh
+npx --yes codex-firefox-bridge@latest doctor
+```
+
+Windows and universal Apple Silicon/Intel macOS installers are also attached to every [GitHub release](https://github.com/SunkenInTime/codex-computer-use-firefox-zen/releases/latest).
+
+### 3. Open the sidebar
+
+Keep the official Codex/ChatGPT Chrome integration installed, then open the Codex sidebar from the toolbar or press `Ctrl+Shift+.` (`Command+Shift+.` on macOS). If Firefox asks for website access, choose **Allow all websites** so browser control continues after navigation and in new tabs.
+
+The add-on and bridge are released together. If their versions drift, the toolbar shows a red **SYNC** badge and opens a recovery screen with both installed versions and the correct update path.
+
+## What works
 
 The port has been exercised against the real signed-in OpenAI sidebar in Zen Browser, not only against mocks.
 
-The inherited July 27-31 ChatGPT extension features are also present in the
-Firefox and Zen Browser build. The packaged application code is byte-for-byte identical to
-the current `1.2.27236.6274` extension installed in Helium for these paths; the
-port changes only the browser compatibility and packaging layers.
+| Experience | Support |
+| --- | --- |
+| Signed-in Codex sidebar and New task UI | ✅ Verified |
+| Semantic page inspection and element lookup | ✅ Verified |
+| Click, type, keyboard, pointer, checkbox, and scroll input | ✅ Verified |
+| Navigation, tab management, history, cookies, and downloads | ✅ Verified |
+| Screenshots and exact viewport emulation | ✅ Verified |
+| File chooser interception and local-file uploads | ✅ Verified |
+| Nested and cross-origin iframe control | ✅ Verified |
+| HTML5 and pointer drag-and-drop | ✅ Verified |
+| Network lifecycle, response bodies, and request interception | ✅ Verified |
+| Locale, timezone, touch, user-agent, and device emulation | ✅ Verified |
+| JavaScript confirm/prompt discovery and replay | ✅ Verified, with a native-dialog caveat |
+
+The inherited ChatGPT browser features are retained too:
 
 | ChatGPT browser feature | Firefox and Zen Browser support |
 | --- | --- |
-| Mention any open tab as chat context | Pass — the `chatgpt.com` bridge and filtered tab provider are retained |
-| Send highlighted page text to ChatGPT | Pass — selection text is forwarded into the sidebar invocation |
-| Right-click a page and choose **Ask ChatGPT** | Pass — coexists with the port's custom Editing Assets menus |
-| Ask about YouTube videos with timestamped captions | Pass — caption retrieval, transcript formatting, and timestamp seeking are retained |
-| Find relevant browser-history pages | Pass — Firefox `history.search` is wired through the inherited browser client; ChatGPT owns the per-request approval UI |
-| Continue chats between the browser and desktop app | Pass — shared thread routes and the `codex://threads/` desktop handoff are retained |
+| Mention any open tab as chat context | ✅ Firefox tab provider retained |
+| Send highlighted page text to ChatGPT | ✅ Selection forwarding retained |
+| Right-click a page and choose **Ask ChatGPT** | ✅ Retained alongside Editing Assets actions |
+| Ask about YouTube videos with timestamped captions | ✅ Caption retrieval and timestamp seeking retained |
+| Find relevant pages from browser history | ✅ Firefox history search wired through the inherited approval UI |
+| Continue chats between browser and desktop app | ✅ Shared thread routes and `codex://threads/` handoff retained |
 
-`tests/test-chatgpt-feature-parity.mjs` guards these inherited surfaces against
-being dropped during a future upstream refresh.
+See [PORT_STATUS.md](PORT_STATUS.md) for detailed evidence and the remaining low-level Firefox limitations. `tests/test-chatgpt-feature-parity.mjs` guards the inherited ChatGPT surfaces against future upstream refreshes.
 
-| Capability | Result |
-| --- | --- |
-| Open/close the signed-in ChatGPT sidebar and render its New task UI | Pass |
-| DOM snapshot and semantic element lookup | Pass |
-| Pointer click, text input, keyboard input, and checkbox input | Pass |
-| Nested cross-origin iframe snapshot, fill, type, click, and DOM computer use | Pass |
-| Wheel scrolling and anchor navigation | Pass |
-| HTML5 drag-and-drop | Pass |
-| File chooser interception and local-file upload | Pass |
-| Visible-tab screenshots | Pass |
-| Tab create/list/activate/close | Pass |
-| Navigate, back, forward, and reload | Pass |
-| Cookies and browser metadata | Pass |
-| Exact viewport override and reset | Pass |
-| Network lifecycle, response bodies, `Fetch` interception, and synthetic fulfillment | Pass |
-| Device, locale, timezone, touch, user-agent, and viewport emulation with reset | Pass |
-| Confirm/prompt discovery and accepted-result replay | Pass, with the native-dialog caveat below |
-| Sidebar and browser automation at the same time | Pass |
+## How the connection works
 
-See [PORT_STATUS.md](PORT_STATUS.md) for the test evidence and the remaining low-level Firefox limitations.
+```text
+Firefox / Zen add-on
+        ↕ native messaging
+Codex Firefox Bridge
+        ↕ local relay
+Official OpenAI extension host
+        ↕
+Codex / ChatGPT
+```
 
-## Install
+Firefox WebExtensions cannot launch arbitrary local programs or reuse a native-messaging host registered only for a Chrome extension ID. The small companion performs that OS-level handoff: it registers for this Firefox add-on, discovers the existing official OpenAI host, and securely relays the local connection.
 
-The Firefox add-on and its companion bridge are versioned together. There are
-three supported ways to install the companion:
+The bridge does not replace Codex, store credentials, or operate a remote service. If OpenAI provides an official Firefox route or another supported local connection, we'd be happy to adopt it and simplify or remove the companion.
 
-- Windows: run `codex-firefox-bridge-<version>-windows-x64-setup.exe`. It installs
-  per-user and does not require administrator access.
-- macOS: open `codex-firefox-bridge-<version>-macos-universal.pkg`. The universal
-  package supports both Apple Silicon and Intel Macs.
-- npm (Windows or macOS):
+## Under the hood
 
-  ```sh
-  npx --yes codex-firefox-bridge@latest install
-  ```
+The compatibility layer adds:
 
-  This is a persistent per-user installation, not a bridge that only lives for
-  the duration of `npx`. Inspect it later with
-  `npx --yes codex-firefox-bridge@latest doctor`, or remove it with the
-  corresponding `uninstall` command.
+- Firefox `sidebar_action` support in place of Chrome `sidePanel`;
+- a persistent Firefox background page in place of a Manifest V3 service worker;
+- Firefox identity metadata while preserving the official host's Chrome-compatible transport family;
+- translation of the `chrome.debugger`/CDP operations used by Codex into Firefox tab, cookie, screenshot, scripting, DOM, input, and network APIs;
+- local-file transfer for controlled file inputs;
+- frame-scoped DOM, input, clipboard, and CDP translation across nested cross-origin iframes;
+- translated network capture, `Fetch` interception, emulation, dialogs, and viewport restoration;
+- native bridge version reporting so the add-on can detect and explain an out-of-sync installation.
 
-Install the companion once, then install the matching signed Firefox add-on.
-The bridge discovers the official OpenAI extension host at runtime, so it does
-not retain a repository path or a machine-specific Codex cache path. An existing
-Codex/ChatGPT installation and the official Chrome integration are still
-required.
+The port currently tracks OpenAI packaged extension version `1.2.27236.6274` (build `ad34341c30168f421705cd15f1633ebe6cea7849`). The inherited application code is byte-for-byte identical for the documented paths; the port changes only browser compatibility and packaging layers.
 
-### Why is the companion required?
+## Local development
 
-Firefox WebExtensions are intentionally sandboxed: they cannot launch an
-arbitrary local program, attach to Codex's private standard-input/output
-transport, or reuse a native-messaging host registered only for a Chrome
-extension ID. Codex currently provides its browser connection through that
-native-host integration rather than a supported Firefox API or authenticated
-local app-server endpoint.
+The OpenAI native extension host must already be installed by ChatGPT/Codex tooling on the development machine.
 
-The small companion is therefore the OS-level handoff Firefox requires. It
-registers for this extension, discovers the existing official OpenAI host, and
-translates the Firefox connection to it. It does not replace Codex or provide a
-remote service.
-
-If OpenAI opens an official Firefox path or another supported local connection,
-we'd love to adopt it and simplify or remove this companion :)
-
-### Local development
-
-The OpenAI native extension host must already be installed by ChatGPT/Codex tooling on this machine.
-
-1. Build and register the Firefox companion:
+1. Build and register the Firefox companion.
 
    Windows:
+
    ```powershell
    .\scripts\register-native-host.ps1
    ```
 
    macOS:
+
    ```sh
    ./scripts/register-native-host.sh
    ```
 
-2. In Zen Browser or Firefox, open `about:debugging#/runtime/this-firefox`.
+2. Open `about:debugging#/runtime/this-firefox` in Zen Browser or Firefox.
 3. Select **Load Temporary Add-on**, then choose `extension/manifest.json`.
-4. Open the Codex computer-use sidebar from the toolbar button or its configured shortcut.
-5. If prompted, choose **Allow all websites**. Firefox requires this host access before Codex can continue controlling a page after navigation or in a newly opened tab. You can revoke it later from **Add-ons and themes → Codex Computer Use for Firefox and Zen Browser → Permissions and data**.
-6. Start a Codex computer-use task. Page execution uses Firefox's standard `scripting.executeScript` API; the add-on does not request the user-script-manager-only `userScripts` permission.
+4. Open the Codex sidebar and grant all-sites access if prompted.
+5. Start a Codex computer-use task.
 
-Temporary add-ons are removed when the browser exits. Permanent installation requires Mozilla signing while retaining the Gecko ID `codex-computer-use-firefox-zen@sunkenintime`.
+Temporary add-ons disappear when the browser exits. Permanent installation requires Mozilla signing while retaining the Gecko ID `codex-computer-use-firefox-zen@sunkenintime`.
 
-To remove only the development registration:
+Remove only the development registration with:
 
-Windows:
 ```powershell
 .\scripts\unregister-native-host.ps1
 ```
 
-macOS:
 ```sh
 ./scripts/unregister-native-host.sh
 ```
@@ -147,27 +162,20 @@ npx --yes web-ext lint --source-dir extension --no-input
 npm run package
 ```
 
-`npm test` validates synchronized release versions, the manifest and compatibility
-surface, then runs native-protocol, upload, and WebSocket-relay integration
-tests. Packaging writes the unsigned extension archive, a matching review-source
-archive generated from the committed tree, and SHA-256 checksums to `dist/`.
+`npm test` checks synchronized release versions, the manifest and compatibility surface, bridge/extension version reporting, and the native protocol, upload, and WebSocket-relay integrations. Packaging writes the unsigned extension archive, a matching review-source archive, and SHA-256 checksums to `dist/`.
 
-Pushing a semantic-version tag such as `v1.4.0` runs the release workflow. It
-builds and tests the extension, a Windows x64 installer, and a universal macOS
-package; verifies that the tag, extension, npm package, and companion versions
-match; generates checksums; and attaches the installers, raw bridge binaries,
-and npm tarball to the GitHub release. It publishes the npm package with
-provenance, then performs a clean installation of that exact public version in
-an isolated macOS home directory. Submit the matching signed Firefox add-on to
-AMO only after that release smoke test passes.
-Prepare the next version with `npm run version:set -- MAJOR.MINOR.PATCH`; this
-updates every version-bearing file together. Production releases should configure
-the signing secrets described in `.github/workflows/release.yml`.
+Pushing a semantic-version tag such as `v1.4.7` runs the release workflow. It builds and tests the extension, Windows installer, and universal macOS package; verifies all release versions; publishes npm with provenance; attaches release artifacts; and smoke-tests a clean install of the exact public npm version. Submit the matching signed Firefox add-on to AMO only after that smoke test passes.
 
-`web-ext lint` currently reports zero errors. Its warnings are from the inherited minified OpenAI distribution (for example dynamic code and HTML construction) plus the compatibility layer's intentional page-world function serialization.
+Prepare a release with:
 
-## Source and distribution note
+```sh
+npm run version:set -- MAJOR.MINOR.PATCH
+```
+
+`web-ext lint` currently reports zero errors. Its expected warnings come from the inherited minified OpenAI distribution and intentional page-world function serialization in the compatibility layer.
+
+## Privacy, independence, and source
+
+Read [PRIVACY.md](PRIVACY.md) for the data-handling disclosure. The native adapter pins its relay origin to the official OpenAI extension ID and rejects unrelated messages.
 
 `extension/codex-sidepanel` and `extension/background.js` are OpenAI's packaged distribution, not a clean-room source reimplementation. Those upstream assets remain subject to OpenAI's applicable terms. The compatibility code in this repository is provided for review and development; no additional license is granted for the bundled upstream assets.
-
-See [PRIVACY.md](PRIVACY.md) for the extension's data-handling disclosure and [PORT_STATUS.md](PORT_STATUS.md) for detailed compatibility evidence.

--- a/extension/companion-required.css
+++ b/extension/companion-required.css
@@ -5,6 +5,10 @@
   color: #171717;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   min-height: 100vh;
   margin: 0;
@@ -28,15 +32,10 @@ main {
 }
 
 .mark {
-  display: grid;
   width: 3rem;
   height: 3rem;
-  place-items: center;
   border-radius: 0.9rem;
-  background: #171717;
-  color: white;
-  font-size: 1.2rem;
-  font-weight: 700;
+  object-fit: cover;
 }
 
 .eyebrow {
@@ -66,6 +65,50 @@ h1 {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.8rem;
+}
+
+.downloads.single {
+  grid-template-columns: 1fr;
+}
+
+.version-status {
+  margin: 0 0 1.25rem;
+  padding: 1rem;
+  border: 1px solid rgba(185, 28, 28, 0.28);
+  border-radius: 0.9rem;
+  background: rgba(254, 226, 226, 0.72);
+}
+
+.version-status h2 {
+  margin: 0 0 0.8rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.version-status dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.version-status dl div {
+  padding: 0.75rem;
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.version-status dt {
+  color: #716b64;
+  font-size: 0.72rem;
+}
+
+.version-status dd {
+  margin: 0.2rem 0 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.92rem;
+  font-weight: 700;
 }
 
 .download {
@@ -189,11 +232,6 @@ ol {
     background: rgba(32, 30, 27, 0.8);
   }
 
-  .mark {
-    background: #f7f3ec;
-    color: #171614;
-  }
-
   .lede,
   .download span,
   .developer-install p,
@@ -207,9 +245,14 @@ ol {
   }
 
   .developer-install,
-  .why {
+  .why,
+  .version-status {
     border-color: rgba(255, 255, 255, 0.12);
     background: rgba(255, 255, 255, 0.03);
+  }
+
+  .version-status dl div {
+    background: rgba(255, 255, 255, 0.05);
   }
 
   .command-row button {

--- a/extension/companion-required.html
+++ b/extension/companion-required.html
@@ -8,15 +8,34 @@
   </head>
   <body>
     <main>
-      <div class="mark" aria-hidden="true">C</div>
-      <p class="eyebrow">One-time setup</p>
-      <h1>Enable the Codex connection</h1>
-      <p class="lede">
+      <img class="mark" src="images/firefox-zen-icon96.png" alt="">
+      <p id="eyebrow" class="eyebrow">One-time setup</p>
+      <h1 id="page-title">Enable the Codex connection</h1>
+      <p id="page-lede" class="lede">
         Firefox needs a small local companion to connect this extension to your
         installed Codex host. It runs only while Codex is connected and does not
         operate a remote service.
       </p>
-      <section class="downloads" aria-label="Companion downloads">
+      <section id="version-status" class="version-status" aria-labelledby="version-status-title" hidden>
+        <h2 id="version-status-title">Installed versions</h2>
+        <dl>
+          <div>
+            <dt>Firefox extension</dt>
+            <dd id="extension-version">—</dd>
+          </div>
+          <div>
+            <dt>Native bridge</dt>
+            <dd id="bridge-version">—</dd>
+          </div>
+        </dl>
+      </section>
+      <section id="extension-update-section" class="downloads single" aria-label="Extension update" hidden>
+        <a class="download recommended" href="https://addons.mozilla.org/firefox/addon/codex-computer-use-for-zen/">
+          <strong>Update the Firefox extension</strong>
+          <span>Install the latest signed build from Mozilla Add-ons</span>
+        </a>
+      </section>
+      <section id="bridge-downloads" class="downloads" aria-label="Companion downloads">
         <a id="windows-download" class="download" href="#">
           <strong>Install for Windows</strong>
           <span>Per-user setup · Windows x64</span>
@@ -26,7 +45,7 @@
           <span>Universal package · Apple Silicon and Intel</span>
         </a>
       </section>
-      <section class="developer-install" aria-labelledby="developer-install-title">
+      <section id="developer-install" class="developer-install" aria-labelledby="developer-install-title">
         <div>
           <p class="option-label">Developer path</p>
           <h2 id="developer-install-title">Install with npm</h2>
@@ -41,9 +60,9 @@
         </div>
       </section>
       <ol>
-        <li>Choose a platform installer or the npm command above.</li>
-        <li>Keep the existing Codex Chrome integration installed.</li>
-        <li>Close this page and reopen the Codex sidebar.</li>
+        <li id="setup-step-one">Choose a platform installer or the npm command above.</li>
+        <li id="setup-step-two">Keep the existing Codex Chrome integration installed.</li>
+        <li id="setup-step-three">Close this page and reopen the Codex sidebar.</li>
       </ol>
       <section class="why" aria-labelledby="why-title">
         <h2 id="why-title">Why is this needed?</h2>

--- a/extension/companion-required.js
+++ b/extension/companion-required.js
@@ -8,7 +8,32 @@
   const macos = document.querySelector("#macos-download");
   const npmCommand = document.querySelector("#npm-command");
   const copyNpmCommand = document.querySelector("#copy-npm-command");
+  const parameters = new URLSearchParams(location.search);
+  const mismatch = parameters.get("reason") === "version-mismatch";
   const command = `npx --yes codex-firefox-bridge@${version} install`;
+
+  if (mismatch) {
+    const bridgeVersion = parameters.get("bridgeVersion") ?? "unknown";
+    const extensionVersion = parameters.get("extensionVersion") ?? version;
+    const extensionIsOlder = bridgeVersion !== "unknown" &&
+      compareVersions(extensionVersion, bridgeVersion) < 0;
+    document.querySelector("#eyebrow").textContent = "Version mismatch";
+    document.querySelector("#page-title").textContent = "Bring both pieces back in sync";
+    document.querySelector("#page-lede").textContent = extensionIsOlder
+      ? "The native bridge is newer than this Firefox extension. Update the signed extension, or reinstall the matching bridge version below."
+      : "The Firefox extension is newer than its native bridge. Update the bridge before using Codex computer use.";
+    document.querySelector("#extension-version").textContent = `v${extensionVersion}`;
+    document.querySelector("#bridge-version").textContent = bridgeVersion === "unknown"
+      ? "Older version"
+      : `v${bridgeVersion}`;
+    document.querySelector("#version-status").hidden = false;
+    document.querySelector("#extension-update-section").hidden = !extensionIsOlder;
+    document.querySelector("#setup-step-one").textContent = extensionIsOlder
+      ? "Install the latest signed extension, or choose a matching bridge installer below."
+      : "Choose a platform installer or run the exact npm command above.";
+    document.querySelector("#setup-step-three").textContent =
+      "Restart Firefox or Zen Browser, then reopen the Codex sidebar.";
+  }
 
   windows.href =
     `${releaseBase}/codex-firefox-bridge-${version}-windows-x64-setup.exe`;
@@ -35,4 +60,19 @@
       macos.classList.add("recommended");
     }
   }).catch(() => {});
+
+  function compareVersions(left, right) {
+    const leftParts = left.split(".").map(Number);
+    const rightParts = right.split(".").map(Number);
+    if ([...leftParts, ...rightParts].some((part) => !Number.isSafeInteger(part))) {
+      return 0;
+    }
+    for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+      const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+      if (difference !== 0) {
+        return difference;
+      }
+    }
+    return 0;
+  }
 })();

--- a/extension/firefox-compat.js
+++ b/extension/firefox-compat.js
@@ -9,6 +9,43 @@
   const OFFICIAL_CHROME_EXTENSION_ID = "hehggadaopoacecdllhhajmbjkdcmajg";
   const FIREFOX_BRIDGE_DISPLAY_NAME = "Codex Firefox Bridge (Firefox and Zen Browser)";
   const BINDING_MESSAGE_SOURCE = "chatgpt-firefox-cdp";
+  const COMPANION_VERSION_FIELD = "_firefoxBridgeVersion";
+  let bridgeVersionMismatchDetected = false;
+
+  function companionPageUrl(parameters = {}) {
+    const url = new URL(firefox.runtime.getURL("companion-required.html"));
+    for (const [key, value] of Object.entries(parameters)) {
+      url.searchParams.set(key, value);
+    }
+    return url.href;
+  }
+
+  function reportBridgeVersion(bridgeVersion) {
+    const extensionVersion = firefox.runtime.getManifest().version;
+    bridgeVersionMismatchDetected = bridgeVersion !== extensionVersion;
+    if (!bridgeVersionMismatchDetected) {
+      firefox.action.setBadgeText({ text: "" }).catch(() => {});
+      return;
+    }
+
+    firefox.action.setBadgeBackgroundColor({ color: "#b91c1c" }).catch(() => {});
+    firefox.action.setBadgeText({ text: "SYNC" }).catch(() => {});
+    const storageKey = `companionVersionMismatchPromptShown:${extensionVersion}:${bridgeVersion}`;
+    firefox.storage.local.get(storageKey).then((stored) => {
+      if (stored[storageKey]) {
+        return;
+      }
+      return firefox.storage.local
+        .set({ [storageKey]: true })
+        .then(() => firefox.tabs.create({
+          url: companionPageUrl({
+            bridgeVersion,
+            extensionVersion,
+            reason: "version-mismatch",
+          }),
+        }));
+    }).catch(() => {});
+  }
 
   const nativeFetch = typeof globalThis.fetch === "function"
     ? globalThis.fetch.bind(globalThis)
@@ -119,12 +156,15 @@
 
   function createNativePortProxy(port) {
     const getInfoRequestIds = new Set();
+    const getInfoBridgeVersions = new Map();
     const listenerWrappers = new WeakMap();
     let receivedNativeMessage = false;
 
     port.onMessage.addListener(() => {
       receivedNativeMessage = true;
-      firefox.action.setBadgeText({ text: "" }).catch(() => {});
+      if (!bridgeVersionMismatchDetected) {
+        firefox.action.setBadgeText({ text: "" }).catch(() => {});
+      }
     });
     port.onDisconnect.addListener(() => {
       if (receivedNativeMessage) {
@@ -151,7 +191,14 @@
       addListener(listener) {
         const wrapped = (message) => {
           if (message?.method === "getInfo" && message.id != null) {
-            getInfoRequestIds.add(String(message.id));
+            const requestId = String(message.id);
+            getInfoRequestIds.add(requestId);
+            getInfoBridgeVersions.set(
+              requestId,
+              typeof message[COMPANION_VERSION_FIELD] === "string"
+                ? message[COMPANION_VERSION_FIELD]
+                : "unknown",
+            );
           }
           listener(message);
         };
@@ -198,6 +245,8 @@
 
             const responseId = message?.id == null ? null : String(message.id);
             if (responseId != null && getInfoRequestIds.delete(responseId) && message?.result) {
+              const bridgeVersion = getInfoBridgeVersions.get(responseId) ?? "unknown";
+              getInfoBridgeVersions.delete(responseId);
               outgoing = {
                 ...message,
                 result: {
@@ -207,13 +256,14 @@
                     ...message.result.metadata,
                     actualBrowserFamily: "firefox",
                     bridgeName: "codex-firefox-bridge",
-                    bridgeVersion: firefox.runtime.getManifest().version,
+                    bridgeVersion,
                     compatibilityFamily: "chrome",
                     extensionId: OFFICIAL_CHROME_EXTENSION_ID,
                     geckoExtensionId: firefox.runtime.id,
                   },
                 },
               };
+              reportBridgeVersion(bridgeVersion);
             }
 
             target.postMessage(outgoing);

--- a/native-host/src/main.rs
+++ b/native-host/src/main.rs
@@ -500,12 +500,27 @@ fn enrich_native_message(payload: Vec<u8>, relay_port: u16, upstream_port: &Atom
     let Ok(mut value) = serde_json::from_slice::<Value>(&payload) else {
         return payload;
     };
-    let changed =
-        enrich_commands(&mut value) | rewrite_websocket_urls(&mut value, relay_port, upstream_port);
+    let changed = enrich_bridge_version(&mut value)
+        | enrich_commands(&mut value)
+        | rewrite_websocket_urls(&mut value, relay_port, upstream_port);
     if !changed {
         return payload;
     }
     serde_json::to_vec(&value).unwrap_or(payload)
+}
+
+fn enrich_bridge_version(value: &mut Value) -> bool {
+    let Value::Object(message) = value else {
+        return false;
+    };
+    if message.get("method").and_then(Value::as_str) != Some("getInfo") {
+        return false;
+    }
+    message.insert(
+        "_firefoxBridgeVersion".into(),
+        Value::String(env!("CARGO_PKG_VERSION").into()),
+    );
+    true
 }
 
 fn enrich_commands(value: &mut Value) -> bool {
@@ -866,6 +881,20 @@ mod tests {
             value["nested"]["url"],
             "ws://127.0.0.1:54321/path?token=test"
         );
+    }
+
+    #[test]
+    fn reports_the_native_bridge_version_during_the_extension_handshake() {
+        let payload = serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "id": "bridge-info",
+            "method": "getInfo"
+        }))
+        .unwrap();
+        let upstream = AtomicU16::new(0);
+        let enriched: Value =
+            serde_json::from_slice(&enrich_native_message(payload, 54321, &upstream)).unwrap();
+        assert_eq!(enriched["_firefoxBridgeVersion"], env!("CARGO_PKG_VERSION"));
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "check": "node scripts/check-version.mjs && node scripts/verify-extension.mjs",
     "version:set": "node scripts/set-version.mjs",
-    "test": "npm run check && node tests/test-sidepanel-focus-compat.mjs && node tests/test-sidepanel-host-access.mjs && node tests/test-sidepanel-bootstrap.mjs && node tests/test-chatgpt-feature-parity.mjs && node tests/test-firefox-compat.mjs && node tests/test-editing-assets.mjs && node tests/test-native-host.mjs",
+    "test": "npm run check && node tests/test-companion-required.mjs && node tests/test-sidepanel-focus-compat.mjs && node tests/test-sidepanel-host-access.mjs && node tests/test-sidepanel-bootstrap.mjs && node tests/test-chatgpt-feature-parity.mjs && node tests/test-firefox-compat.mjs && node tests/test-editing-assets.mjs && node tests/test-native-host.mjs",
     "package": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-extension.ps1"
   }
 }

--- a/scripts/verify-extension.mjs
+++ b/scripts/verify-extension.mjs
@@ -58,6 +58,8 @@ for (const setupFile of ["companion-required.html", "companion-required.css", "c
 new vm.Script(read("extension/companion-required.js"), { filename: "companion-required.js" });
 const setupHtml = read("extension/companion-required.html");
 assert(setupHtml.includes("codex-firefox-bridge@"), "The npm installation path is missing from setup.");
+assert(setupHtml.includes("https://addons.mozilla.org/firefox/addon/codex-computer-use-for-zen/"), "The signed Firefox extension update path is missing from setup.");
+assert(setupHtml.includes('id="version-status"'), "The setup page cannot show installed version details.");
 assert(setupHtml.includes("Why is this needed?"), "The setup page must explain why the companion is required.");
 for (const size of ["16", "24", "32", "48", "64", "96", "128"]) {
   assert(size in manifest.icons, `Missing ${size}px icon declaration.`);
@@ -73,6 +75,7 @@ for (const match of sidebarHtml.matchAll(/(?:src|href)="\.\/([^"?#]+)"/gu)) {
 
 const compatibilitySource = read("extension/firefox-compat.js");
 assert(compatibilitySource.includes("companionSetupPromptShown:"), "Missing one-time companion setup guidance.");
+assert(compatibilitySource.includes("companionVersionMismatchPromptShown:"), "Missing bridge version mismatch guidance.");
 const coreCdpMethods = [
   "DOM.describeNode",
   "DOM.getBoxModel",

--- a/tests/test-companion-required.mjs
+++ b/tests/test-companion-required.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import vm from "node:vm";
+
+const source = fs.readFileSync("extension/companion-required.js", "utf8");
+const elementIds = [
+  "bridge-downloads",
+  "bridge-version",
+  "copy-npm-command",
+  "developer-install",
+  "eyebrow",
+  "extension-update-section",
+  "extension-version",
+  "macos-download",
+  "npm-command",
+  "page-lede",
+  "page-title",
+  "setup-step-one",
+  "setup-step-two",
+  "setup-step-three",
+  "version-status",
+  "windows-download",
+];
+
+async function render(search) {
+  const elements = new Map(elementIds.map((id) => [id, {
+    addEventListener() {},
+    classList: { add() {} },
+    hidden: id === "extension-update-section" || id === "version-status",
+    href: "",
+    textContent: "",
+  }]));
+  const context = vm.createContext({
+    URLSearchParams,
+    browser: {
+      runtime: {
+        getManifest() { return { version: "1.4.7" }; },
+        async getPlatformInfo() { return { os: "mac" }; },
+      },
+    },
+    document: {
+      querySelector(selector) { return elements.get(selector.slice(1)); },
+    },
+    location: { search },
+    navigator: { clipboard: { async writeText() {} } },
+    setTimeout,
+  });
+  new vm.Script(source, { filename: "companion-required.js" }).runInContext(context);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return elements;
+}
+
+const olderBridge = await render("?reason=version-mismatch&extensionVersion=1.4.7&bridgeVersion=1.4.6");
+assert.equal(olderBridge.get("eyebrow").textContent, "Version mismatch");
+assert.equal(olderBridge.get("extension-version").textContent, "v1.4.7");
+assert.equal(olderBridge.get("bridge-version").textContent, "v1.4.6");
+assert.equal(olderBridge.get("version-status").hidden, false);
+assert.equal(olderBridge.get("extension-update-section").hidden, true);
+assert.equal(olderBridge.get("npm-command").textContent, "npx --yes codex-firefox-bridge@1.4.7 install");
+assert.match(olderBridge.get("page-lede").textContent, /Update the bridge/u);
+
+const olderExtension = await render("?reason=version-mismatch&extensionVersion=1.4.7&bridgeVersion=1.4.8");
+assert.equal(olderExtension.get("extension-update-section").hidden, false);
+assert.equal(olderExtension.get("bridge-downloads").hidden, false);
+assert.equal(olderExtension.get("developer-install").hidden, false);
+assert.match(olderExtension.get("page-lede").textContent, /Update the signed extension/u);
+assert.match(olderExtension.get("setup-step-one").textContent, /matching bridge installer/u);
+assert.match(olderExtension.get("setup-step-three").textContent, /Restart Firefox or Zen Browser/u);
+
+const legacyBridge = await render("?reason=version-mismatch&extensionVersion=1.4.7&bridgeVersion=unknown");
+assert.equal(legacyBridge.get("bridge-version").textContent, "Older version");
+assert.match(legacyBridge.get("page-lede").textContent, /Update the bridge/u);
+
+console.log(JSON.stringify({
+  ok: true,
+  olderBridgeRecovery: true,
+  olderExtensionRecovery: true,
+  legacyBridgeRecovery: true,
+}, null, 2));

--- a/tests/test-firefox-compat.mjs
+++ b/tests/test-firefox-compat.mjs
@@ -31,6 +31,7 @@ const executedFaviconTargets = [];
 const createdTabs = [];
 const fetchedUrls = [];
 const storedValues = {};
+const badgeTexts = [];
 let allWebsiteAccessGranted = true;
 let captureVisibleTabCalls = [];
 let targetTabActive = true;
@@ -52,7 +53,7 @@ const browser = {
   },
   action: {
     async setBadgeBackgroundColor() {},
-    async setBadgeText() {},
+    async setBadgeText(details) { badgeTexts.push(details.text); },
   },
   permissions: {
     async contains(details) {
@@ -167,7 +168,11 @@ assert.equal(
 
 const identityPort = context.chrome.runtime.connectNative("com.openai.codexextension");
 identityPort.onMessage.addListener(() => {});
-nativePort.onMessage.emit({ id: "bridge-info", method: "getInfo" });
+nativePort.onMessage.emit({
+  _firefoxBridgeVersion: "test",
+  id: "bridge-info",
+  method: "getInfo",
+});
 identityPort.postMessage({
   id: "bridge-info",
   result: {
@@ -184,6 +189,35 @@ assert.equal(bridgeIdentity.metadata.compatibilityFamily, "chrome");
 assert.equal(bridgeIdentity.metadata.extensionId, "hehggadaopoacecdllhhajmbjkdcmajg");
 assert.equal(bridgeIdentity.metadata.geckoExtensionId, "codex-computer-use-firefox-zen@sunkenintime");
 assert.equal(bridgeIdentity.metadata.extensionInstanceId, "test-instance");
+assert.equal(createdTabs.length, 0, "Matching bridge and extension versions must not show update guidance.");
+
+nativePort.onMessage.emit({
+  _firefoxBridgeVersion: "0.9.0",
+  id: "mismatched-bridge-info",
+  method: "getInfo",
+});
+identityPort.postMessage({
+  id: "mismatched-bridge-info",
+  result: { name: "Chrome", metadata: {} },
+});
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.equal(nativePostedMessages.at(-1).result.metadata.bridgeVersion, "0.9.0");
+assert.equal(badgeTexts.at(-1), "SYNC", "A version mismatch must remain visible on the toolbar action.");
+assert.match(createdTabs.at(-1).url, /companion-required\.html\?/u);
+assert.match(createdTabs.at(-1).url, /reason=version-mismatch/u);
+assert.match(createdTabs.at(-1).url, /bridgeVersion=0\.9\.0/u);
+assert.match(createdTabs.at(-1).url, /extensionVersion=test/u);
+createdTabs.length = 0;
+
+nativePort.onMessage.emit({ id: "legacy-bridge-info", method: "getInfo" });
+identityPort.postMessage({
+  id: "legacy-bridge-info",
+  result: { name: "Chrome", metadata: {} },
+});
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.equal(nativePostedMessages.at(-1).result.metadata.bridgeVersion, "unknown");
+assert.match(createdTabs.at(-1).url, /bridgeVersion=unknown/u, "A pre-version-reporting bridge must be treated as outdated.");
+createdTabs.length = 0;
 
 const faviconResponse = await context.fetch("moz-extension://test/_favicon/?pageUrl=https%3A%2F%2Ftop.test%2F&size=32");
 assert.equal(faviconResponse.ok, true);


### PR DESCRIPTION
## Summary

- rewrite the README around the product value, a three-step install flow, verified capabilities, and the local bridge architecture
- add the live Mozilla Add-ons link, Firefox/Zen artwork, and release/npm badges
- have the native bridge report its real package version during the existing `getInfo` handshake
- show a persistent `SYNC` badge and an actionable recovery screen when the bridge and extension versions differ
- handle legacy bridges that predate version reporting as outdated instead of silently assuming they match

## Root cause

The setup UI already handled a missing native companion, but version drift was not detected. The compatibility layer populated `metadata.bridgeVersion` from the extension manifest itself, so an older installed bridge appeared to be the same version as the add-on.

## Validation

- `npm test`
- `cargo test --locked --manifest-path native-host/Cargo.toml` (11 passed)
- `cargo fmt --check --manifest-path native-host/Cargo.toml`
- `npx --yes web-ext lint --source-dir extension --no-input` (0 errors, 0 notices, 72 expected inherited warnings)

The new focused coverage exercises recovery for an older bridge, an older extension, and a legacy bridge without version metadata.