### PR TITLE
Embed and explain Firefox companion setup

### DIFF
--- a/extension/codex-sidepanel/firefox-companion-setup.css
+++ b/extension/codex-sidepanel/firefox-companion-setup.css
@@ -1,0 +1,407 @@
+.firefox-companion-setup-root {
+  height: 100%;
+}
+
+.firefox-companion-setup {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100vh;
+  overflow-y: auto;
+  padding: clamp(16px, 5vw, 32px);
+  background: var(--color-token-main-surface-primary, #181818);
+  color: var(--color-token-foreground, #fff);
+  font-family: var(--font-openai-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+}
+
+.firefox-companion-setup *,
+.firefox-companion-setup *::before,
+.firefox-companion-setup *::after {
+  box-sizing: border-box;
+}
+
+.firefox-companion-setup__panel {
+  width: min(100%, 560px);
+  margin: 0 auto;
+  padding: clamp(22px, 6vw, 36px);
+  border: 1px solid var(--color-token-border-heavy, rgba(255, 255, 255, 0.14));
+  border-radius: var(--radius-3xl, 20px);
+  background: var(--color-background-elevated-secondary, rgba(255, 255, 255, 0.025));
+}
+
+.firefox-companion-setup__mark {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border-radius: 11px;
+  background: var(--color-token-foreground, #fff);
+  color: var(--color-token-main-surface-primary, #181818);
+  box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.18));
+}
+
+.firefox-companion-setup__mark svg {
+  width: 25px;
+  height: 25px;
+}
+
+.firefox-companion-setup__eyebrow,
+.firefox-companion-setup__option-label {
+  margin: 24px 0 7px;
+  color: var(--color-accent-orange, #fb6a22);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.firefox-companion-setup__title {
+  max-width: 460px;
+  margin: 0;
+  color: inherit;
+  font-size: clamp(34px, 8vw, 50px);
+  font-weight: 650;
+  letter-spacing: -0.055em;
+  line-height: 0.98;
+}
+
+.firefox-companion-setup__lede {
+  margin: 20px 0 24px;
+  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+.firefox-companion-setup__connection-flow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.firefox-companion-setup__connection-node {
+  min-width: 0;
+  flex: 1;
+  padding: 9px 6px;
+  border-radius: var(--radius-lg, 10px);
+  background: var(--color-background-button-secondary, rgba(255, 255, 255, 0.06));
+  text-align: center;
+}
+
+.firefox-companion-setup__connection-node strong,
+.firefox-companion-setup__connection-node span {
+  display: block;
+}
+
+.firefox-companion-setup__connection-node strong {
+  font-size: 10px;
+  line-height: 1.25;
+}
+
+.firefox-companion-setup__connection-node span {
+  margin-top: 2px;
+  color: var(--color-token-text-tertiary, rgba(255, 255, 255, 0.55));
+  font-size: 9px;
+  line-height: 1.2;
+}
+
+.firefox-companion-setup__connection-arrow {
+  color: var(--color-token-text-tertiary, rgba(255, 255, 255, 0.55));
+  font-size: 12px;
+}
+
+.firefox-companion-setup .firefox-companion-setup__prerequisite {
+  border-color: color-mix(in srgb, var(--color-accent-orange, #fb6a22) 38%, transparent);
+  background: color-mix(in srgb, var(--color-accent-orange, #fb6a22) 7%, transparent);
+}
+
+.firefox-companion-setup__compact-steps {
+  display: grid;
+  gap: 6px;
+  margin: 12px 0;
+  padding-left: 20px;
+  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.firefox-companion-setup__text-link {
+  color: var(--color-token-foreground, #fff);
+  font-size: 11px;
+  font-weight: 600;
+  text-underline-offset: 3px;
+}
+
+.firefox-companion-setup__note {
+  margin: 12px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-token-border, rgba(255, 255, 255, 0.08));
+  color: var(--color-token-text-tertiary, rgba(255, 255, 255, 0.55));
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.firefox-companion-setup__section-title {
+  margin: 22px 0 0;
+  color: inherit;
+  font-size: 16px;
+}
+
+.firefox-companion-setup__section-copy {
+  margin: 6px 0 14px;
+  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.firefox-companion-setup__downloads {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.firefox-companion-setup__download {
+  min-width: 0;
+  padding: 15px;
+  border: 1px solid var(--color-token-border-heavy, rgba(255, 255, 255, 0.14));
+  border-radius: var(--radius-xl, 12px);
+  color: inherit;
+  text-decoration: none;
+  transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+}
+
+.firefox-companion-setup__download strong,
+.firefox-companion-setup__download span {
+  display: block;
+}
+
+.firefox-companion-setup__download strong {
+  font-size: 14px;
+  line-height: 1.25;
+}
+
+.firefox-companion-setup__download span {
+  margin-top: 5px;
+  color: var(--color-token-text-tertiary, rgba(255, 255, 255, 0.55));
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.firefox-companion-setup__download:hover,
+.firefox-companion-setup__download--recommended {
+  border-color: var(--color-token-foreground, #fff);
+  background: var(--color-background-button-secondary, rgba(255, 255, 255, 0.05));
+}
+
+.firefox-companion-setup__download:hover {
+  transform: translateY(-1px);
+}
+
+.firefox-companion-setup__download:focus-visible,
+.firefox-companion-setup button:focus-visible,
+.firefox-companion-setup summary:focus-visible,
+.firefox-companion-setup__text-link:focus-visible,
+.firefox-companion-setup__guide:focus-visible {
+  outline: 2px solid var(--color-border-focus, #339cff);
+  outline-offset: 2px;
+}
+
+.firefox-companion-setup__connection,
+.firefox-companion-setup__prerequisite,
+.firefox-companion-setup__developer,
+.firefox-companion-setup__diagnostics,
+.firefox-companion-setup__help {
+  margin-top: 12px;
+  padding: 16px;
+  border: 1px solid var(--color-token-border, rgba(255, 255, 255, 0.08));
+  border-radius: var(--radius-xl, 12px);
+  background: var(--color-background-elevated-secondary, rgba(255, 255, 255, 0.025));
+}
+
+.firefox-companion-setup__prerequisite h2,
+.firefox-companion-setup__developer h2,
+.firefox-companion-setup__diagnostics h2 {
+  margin: 0;
+  color: inherit;
+  font-size: 15px;
+}
+
+.firefox-companion-setup__option-label {
+  margin: 0 0 3px;
+  font-size: 10px;
+}
+
+.firefox-companion-setup__muted,
+.firefox-companion-setup__help p {
+  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.firefox-companion-setup__muted {
+  margin: 5px 0 0;
+}
+
+.firefox-companion-setup__command-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.firefox-companion-setup__command-row code {
+  min-width: 0;
+  flex: 1;
+  overflow-x: auto;
+  padding: 10px 11px;
+  border-radius: var(--radius-lg, 10px);
+  background: var(--gray-1000, #0d0d0d);
+  color: var(--gray-100, #ededed);
+  font-family: var(--font-mono-default, ui-monospace, monospace);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.firefox-companion-setup__copy,
+.firefox-companion-setup__retry,
+.firefox-companion-setup__guide {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-lg, 10px);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.firefox-companion-setup__copy {
+  min-width: 64px;
+  padding: 0 12px;
+  border: 1px solid var(--color-token-border-heavy, rgba(255, 255, 255, 0.14));
+  background: transparent;
+  color: inherit;
+}
+
+.firefox-companion-setup__steps {
+  display: grid;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: setup-step;
+}
+
+.firefox-companion-setup__step {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  column-gap: 9px;
+  counter-increment: setup-step;
+}
+
+.firefox-companion-setup__step::before {
+  content: counter(setup-step);
+  display: grid;
+  grid-row: 1 / span 2;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--color-background-button-secondary, rgba(255, 255, 255, 0.06));
+  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.firefox-companion-setup__step strong {
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.firefox-companion-setup__step span {
+  color: var(--color-token-text-tertiary, rgba(255, 255, 255, 0.55));
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.firefox-companion-setup__help {
+  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
+}
+
+.firefox-companion-setup__help summary {
+  color: var(--color-token-foreground, #fff);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.firefox-companion-setup__help p {
+  margin: 10px 0 0;
+}
+
+.firefox-companion-setup__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  margin-top: 18px;
+}
+
+.firefox-companion-setup__retry,
+.firefox-companion-setup__guide {
+  min-height: 36px;
+  padding: 0 15px;
+}
+
+.firefox-companion-setup__retry {
+  border: 1px solid var(--color-token-foreground, #fff);
+  background: var(--color-token-foreground, #fff);
+  color: var(--color-token-main-surface-primary, #181818);
+}
+
+.firefox-companion-setup__guide {
+  border: 1px solid var(--color-token-border-heavy, rgba(255, 255, 255, 0.14));
+  background: transparent;
+  color: inherit;
+  text-decoration: none;
+}
+
+.firefox-companion-setup__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 480px) {
+  .firefox-companion-setup__panel {
+    padding: 22px 18px;
+    border-radius: var(--radius-2xl, 16px);
+  }
+
+  .firefox-companion-setup__downloads {
+    grid-template-columns: 1fr;
+  }
+
+  .firefox-companion-setup__title {
+    font-size: clamp(32px, 12vw, 42px);
+  }
+
+  .firefox-companion-setup__connection-flow {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .firefox-companion-setup__connection-arrow {
+    line-height: 0.8;
+    text-align: center;
+    transform: rotate(90deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .firefox-companion-setup__download {
+    transition: none;
+  }
+}

--- a/extension/codex-sidepanel/firefox-companion-setup.css
+++ b/extension/codex-sidepanel/firefox-companion-setup.css
@@ -2,15 +2,42 @@
   height: 100%;
 }
 
+/*
+ * Mirrors the upstream sidepanel onboarding surface (_onboardingSurface /
+ * _onboardingButton): flat light/dark surface, centered column, blossom mark,
+ * heading-lg title, and rounded-full primary button. Colors are hardcoded per
+ * prefers-color-scheme exactly like upstream, because this screen renders
+ * before the app finishes booting its theme tokens.
+ */
 .firefox-companion-setup {
+  --fcs-surface: #fff;
+  --fcs-foreground: #0d0d0d;
+  --fcs-secondary: color-mix(in srgb, var(--fcs-foreground) 65%, transparent);
+  --fcs-tertiary: color-mix(in srgb, var(--fcs-foreground) 45%, transparent);
+  --fcs-border: color-mix(in srgb, var(--fcs-foreground) 10%, transparent);
+  --fcs-border-heavy: color-mix(in srgb, var(--fcs-foreground) 15%, transparent);
+  --fcs-surface-secondary: color-mix(in srgb, var(--fcs-foreground) 5%, transparent);
+  --fcs-button-bg: #0d0d0d;
+  --fcs-button-fg: #fff;
   box-sizing: border-box;
   width: 100%;
   height: 100vh;
   overflow-y: auto;
-  padding: clamp(16px, 5vw, 32px);
-  background: var(--color-token-main-surface-primary, #181818);
-  color: var(--color-token-foreground, #fff);
-  font-family: var(--font-openai-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+  padding: 40px 24px 48px;
+  background: var(--fcs-surface);
+  color: var(--fcs-foreground);
+  font-family: var(--font-openai-sans, "OpenAI Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+@media (prefers-color-scheme: dark) {
+  .firefox-companion-setup {
+    --fcs-surface: #212121;
+    --fcs-foreground: #f4f4f4;
+    --fcs-button-bg: #f4f4f4;
+    --fcs-button-fg: #212121;
+  }
 }
 
 .firefox-companion-setup *,
@@ -20,188 +47,46 @@
 }
 
 .firefox-companion-setup__panel {
-  width: min(100%, 560px);
-  margin: 0 auto;
-  padding: clamp(22px, 6vw, 36px);
-  border: 1px solid var(--color-token-border-heavy, rgba(255, 255, 255, 0.14));
-  border-radius: var(--radius-3xl, 20px);
-  background: var(--color-background-elevated-secondary, rgba(255, 255, 255, 0.025));
-}
-
-.firefox-companion-setup__mark {
-  display: grid;
-  width: 44px;
-  height: 44px;
-  place-items: center;
-  border-radius: 11px;
-  background: var(--color-token-foreground, #fff);
-  color: var(--color-token-main-surface-primary, #181818);
-  box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.18));
-}
-
-.firefox-companion-setup__mark svg {
-  width: 25px;
-  height: 25px;
-}
-
-.firefox-companion-setup__eyebrow,
-.firefox-companion-setup__option-label {
-  margin: 24px 0 7px;
-  color: var(--color-accent-orange, #fb6a22);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.13em;
-  text-transform: uppercase;
-}
-
-.firefox-companion-setup__title {
-  max-width: 460px;
-  margin: 0;
-  color: inherit;
-  font-size: clamp(34px, 8vw, 50px);
-  font-weight: 650;
-  letter-spacing: -0.055em;
-  line-height: 0.98;
-}
-
-.firefox-companion-setup__lede {
-  margin: 20px 0 24px;
-  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
-  font-size: 15px;
-  line-height: 1.55;
-}
-
-.firefox-companion-setup__connection-flow {
   display: flex;
-  align-items: center;
-  gap: 6px;
+  width: min(100%, 400px);
+  margin: 0 auto;
+  flex-direction: column;
 }
 
-.firefox-companion-setup__connection-node {
-  min-width: 0;
-  flex: 1;
-  padding: 9px 6px;
-  border-radius: var(--radius-lg, 10px);
-  background: var(--color-background-button-secondary, rgba(255, 255, 255, 0.06));
+.firefox-companion-setup__logo {
+  width: 72px;
+  height: 72px;
+  margin: 0 auto;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.firefox-companion-setup__eyebrow {
+  margin: 20px 0 0;
+  color: var(--fcs-tertiary);
+  font-size: 12px;
+  font-weight: 500;
   text-align: center;
 }
 
-.firefox-companion-setup__connection-node strong,
-.firefox-companion-setup__connection-node span {
-  display: block;
-}
-
-.firefox-companion-setup__connection-node strong {
-  font-size: 10px;
-  line-height: 1.25;
-}
-
-.firefox-companion-setup__connection-node span {
-  margin-top: 2px;
-  color: var(--color-token-text-tertiary, rgba(255, 255, 255, 0.55));
-  font-size: 9px;
+.firefox-companion-setup__title {
+  margin: 4px auto 0;
+  max-width: 300px;
+  color: inherit;
+  font-size: 24px;
+  font-weight: 500;
+  letter-spacing: -0.3px;
   line-height: 1.2;
+  text-align: center;
 }
 
-.firefox-companion-setup__connection-arrow {
-  color: var(--color-token-text-tertiary, rgba(255, 255, 255, 0.55));
-  font-size: 12px;
-}
-
-.firefox-companion-setup .firefox-companion-setup__prerequisite {
-  border-color: color-mix(in srgb, var(--color-accent-orange, #fb6a22) 38%, transparent);
-  background: color-mix(in srgb, var(--color-accent-orange, #fb6a22) 7%, transparent);
-}
-
-.firefox-companion-setup__compact-steps {
-  display: grid;
-  gap: 6px;
-  margin: 12px 0;
-  padding-left: 20px;
-  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
-  font-size: 11px;
-  line-height: 1.45;
-}
-
-.firefox-companion-setup__text-link {
-  color: var(--color-token-foreground, #fff);
-  font-size: 11px;
-  font-weight: 600;
-  text-underline-offset: 3px;
-}
-
-.firefox-companion-setup__note {
-  margin: 12px 0 0;
-  padding-top: 12px;
-  border-top: 1px solid var(--color-token-border, rgba(255, 255, 255, 0.08));
-  color: var(--color-token-text-tertiary, rgba(255, 255, 255, 0.55));
-  font-size: 10px;
-  line-height: 1.45;
-}
-
-.firefox-companion-setup__section-title {
-  margin: 22px 0 0;
-  color: inherit;
-  font-size: 16px;
-}
-
-.firefox-companion-setup__section-copy {
-  margin: 6px 0 14px;
-  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
-  font-size: 12px;
-  line-height: 1.5;
-}
-
-.firefox-companion-setup__downloads {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.firefox-companion-setup__download {
-  min-width: 0;
-  padding: 15px;
-  border: 1px solid var(--color-token-border-heavy, rgba(255, 255, 255, 0.14));
-  border-radius: var(--radius-xl, 12px);
-  color: inherit;
-  text-decoration: none;
-  transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
-}
-
-.firefox-companion-setup__download strong,
-.firefox-companion-setup__download span {
-  display: block;
-}
-
-.firefox-companion-setup__download strong {
+.firefox-companion-setup__lede {
+  margin: 12px auto 24px;
+  max-width: 340px;
+  color: var(--fcs-secondary);
   font-size: 14px;
-  line-height: 1.25;
-}
-
-.firefox-companion-setup__download span {
-  margin-top: 5px;
-  color: var(--color-token-text-tertiary, rgba(255, 255, 255, 0.55));
-  font-size: 11px;
-  line-height: 1.35;
-}
-
-.firefox-companion-setup__download:hover,
-.firefox-companion-setup__download--recommended {
-  border-color: var(--color-token-foreground, #fff);
-  background: var(--color-background-button-secondary, rgba(255, 255, 255, 0.05));
-}
-
-.firefox-companion-setup__download:hover {
-  transform: translateY(-1px);
-}
-
-.firefox-companion-setup__download:focus-visible,
-.firefox-companion-setup button:focus-visible,
-.firefox-companion-setup summary:focus-visible,
-.firefox-companion-setup__text-link:focus-visible,
-.firefox-companion-setup__guide:focus-visible {
-  outline: 2px solid var(--color-border-focus, #339cff);
-  outline-offset: 2px;
+  line-height: 1.5;
+  text-align: center;
 }
 
 .firefox-companion-setup__connection,
@@ -211,9 +96,15 @@
 .firefox-companion-setup__help {
   margin-top: 12px;
   padding: 16px;
-  border: 1px solid var(--color-token-border, rgba(255, 255, 255, 0.08));
-  border-radius: var(--radius-xl, 12px);
-  background: var(--color-background-elevated-secondary, rgba(255, 255, 255, 0.025));
+  border: 1px solid var(--fcs-border);
+  border-radius: 16px;
+}
+
+.firefox-companion-setup__option-label {
+  margin: 0 0 2px;
+  color: var(--fcs-tertiary);
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .firefox-companion-setup__prerequisite h2,
@@ -221,23 +112,154 @@
 .firefox-companion-setup__diagnostics h2 {
   margin: 0;
   color: inherit;
-  font-size: 15px;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
 }
 
-.firefox-companion-setup__option-label {
-  margin: 0 0 3px;
+.firefox-companion-setup__connection-flow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.firefox-companion-setup__connection-node {
+  min-width: 0;
+  flex: 1;
+  padding: 8px 6px;
+  border-radius: 10px;
+  background: var(--fcs-surface-secondary);
+  text-align: center;
+}
+
+.firefox-companion-setup__connection-node strong,
+.firefox-companion-setup__connection-node span {
+  display: block;
+}
+
+.firefox-companion-setup__connection-node strong {
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.firefox-companion-setup__connection-node span {
+  margin-top: 1px;
+  color: var(--fcs-tertiary);
   font-size: 10px;
+  line-height: 1.3;
 }
 
-.firefox-companion-setup__muted,
-.firefox-companion-setup__help p {
-  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
+.firefox-companion-setup__connection-arrow {
+  flex: none;
+  color: var(--fcs-tertiary);
+  font-size: 12px;
+}
+
+.firefox-companion-setup__compact-steps {
+  display: grid;
+  gap: 6px;
+  margin: 10px 0;
+  padding-left: 18px;
+  color: var(--fcs-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.firefox-companion-setup__text-link {
+  color: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration-color: var(--fcs-tertiary);
+  text-underline-offset: 3px;
+}
+
+.firefox-companion-setup__note {
+  margin: 12px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--fcs-border);
+  color: var(--fcs-tertiary);
   font-size: 12px;
   line-height: 1.5;
 }
 
-.firefox-companion-setup__muted {
-  margin: 5px 0 0;
+.firefox-companion-setup__section-title {
+  margin: 24px 0 0;
+  color: inherit;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.1px;
+}
+
+.firefox-companion-setup__section-copy {
+  margin: 4px 0 12px;
+  color: var(--fcs-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.firefox-companion-setup__muted,
+.firefox-companion-setup__help p {
+  margin: 4px 0 0;
+  color: var(--fcs-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.firefox-companion-setup__downloads {
+  display: grid;
+  gap: 8px;
+}
+
+.firefox-companion-setup__download {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 1px solid var(--fcs-border);
+  border-radius: 12px;
+  color: inherit;
+  text-decoration: none;
+  transition: background 140ms ease;
+}
+
+.firefox-companion-setup__download:hover {
+  background: var(--fcs-surface-secondary);
+}
+
+.firefox-companion-setup__download--recommended {
+  border-color: var(--fcs-border-heavy);
+  background: var(--fcs-surface-secondary);
+}
+
+.firefox-companion-setup__download-text {
+  min-width: 0;
+  flex: 1;
+}
+
+.firefox-companion-setup__download strong {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.firefox-companion-setup__download span {
+  display: block;
+  margin-top: 2px;
+  color: var(--fcs-tertiary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.firefox-companion-setup__download::after {
+  content: "↓";
+  flex: none;
+  color: var(--fcs-tertiary);
+  font-size: 14px;
 }
 
 .firefox-companion-setup__command-row {
@@ -250,12 +272,13 @@
   min-width: 0;
   flex: 1;
   overflow-x: auto;
-  padding: 10px 11px;
-  border-radius: var(--radius-lg, 10px);
-  background: var(--gray-1000, #0d0d0d);
-  color: var(--gray-100, #ededed);
-  font-family: var(--font-mono-default, ui-monospace, monospace);
-  font-size: 11px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--fcs-surface-secondary);
+  color: inherit;
+  font-family: var(--font-mono-default, ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, monospace);
+  font-size: 12px;
+  line-height: 1.5;
   white-space: nowrap;
 }
 
@@ -265,25 +288,30 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--radius-lg, 10px);
+  border-radius: 9999px;
   font: inherit;
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
+  transition: opacity 140ms ease, background 140ms ease;
 }
 
 .firefox-companion-setup__copy {
   min-width: 64px;
-  padding: 0 12px;
-  border: 1px solid var(--color-token-border-heavy, rgba(255, 255, 255, 0.14));
+  padding: 0 14px;
+  border: 1px solid var(--fcs-border-heavy);
   background: transparent;
   color: inherit;
+}
+
+.firefox-companion-setup__copy:hover {
+  background: var(--fcs-surface-secondary);
 }
 
 .firefox-companion-setup__steps {
   display: grid;
   gap: 10px;
-  margin: 20px 0;
+  margin: 20px 0 0;
   padding: 0;
   list-style: none;
   counter-reset: setup-step;
@@ -291,8 +319,8 @@
 
 .firefox-companion-setup__step {
   display: grid;
-  grid-template-columns: 24px 1fr;
-  column-gap: 9px;
+  grid-template-columns: 20px 1fr;
+  column-gap: 10px;
   counter-increment: setup-step;
 }
 
@@ -300,35 +328,32 @@
   content: counter(setup-step);
   display: grid;
   grid-row: 1 / span 2;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   place-items: center;
   border-radius: 50%;
-  background: var(--color-background-button-secondary, rgba(255, 255, 255, 0.06));
-  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
-  font-size: 10px;
-  font-weight: 700;
+  background: var(--fcs-surface-secondary);
+  color: var(--fcs-secondary);
+  font-size: 11px;
+  font-weight: 600;
 }
 
 .firefox-companion-setup__step strong {
-  font-size: 12px;
-  line-height: 1.35;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.5;
 }
 
 .firefox-companion-setup__step span {
-  color: var(--color-token-text-tertiary, rgba(255, 255, 255, 0.55));
-  font-size: 11px;
-  line-height: 1.45;
-}
-
-.firefox-companion-setup__help {
-  color: var(--color-token-text-secondary, rgba(255, 255, 255, 0.7));
+  color: var(--fcs-tertiary);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .firefox-companion-setup__help summary {
-  color: var(--color-token-foreground, #fff);
-  font-size: 12px;
-  font-weight: 600;
+  color: inherit;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
 }
 
@@ -339,27 +364,45 @@
 .firefox-companion-setup__actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 9px;
-  margin-top: 18px;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 24px;
 }
 
 .firefox-companion-setup__retry,
 .firefox-companion-setup__guide {
   min-height: 36px;
-  padding: 0 15px;
+  padding: 0 16px;
 }
 
 .firefox-companion-setup__retry {
-  border: 1px solid var(--color-token-foreground, #fff);
-  background: var(--color-token-foreground, #fff);
-  color: var(--color-token-main-surface-primary, #181818);
+  border: none;
+  background: var(--fcs-button-bg);
+  color: var(--fcs-button-fg);
+}
+
+.firefox-companion-setup__retry:hover {
+  opacity: 0.85;
 }
 
 .firefox-companion-setup__guide {
-  border: 1px solid var(--color-token-border-heavy, rgba(255, 255, 255, 0.14));
+  border: 1px solid var(--fcs-border-heavy);
   background: transparent;
   color: inherit;
   text-decoration: none;
+}
+
+.firefox-companion-setup__guide:hover {
+  background: var(--fcs-surface-secondary);
+}
+
+.firefox-companion-setup__download:focus-visible,
+.firefox-companion-setup button:focus-visible,
+.firefox-companion-setup summary:focus-visible,
+.firefox-companion-setup__text-link:focus-visible,
+.firefox-companion-setup__guide:focus-visible {
+  outline: 2px solid var(--color-border-focus, #0285ff);
+  outline-offset: 2px;
 }
 
 .firefox-companion-setup__sr-only {
@@ -374,18 +417,9 @@
   border: 0;
 }
 
-@media (max-width: 480px) {
-  .firefox-companion-setup__panel {
-    padding: 22px 18px;
-    border-radius: var(--radius-2xl, 16px);
-  }
-
-  .firefox-companion-setup__downloads {
-    grid-template-columns: 1fr;
-  }
-
-  .firefox-companion-setup__title {
-    font-size: clamp(32px, 12vw, 42px);
+@media (max-width: 380px) {
+  .firefox-companion-setup {
+    padding: 32px 16px 40px;
   }
 
   .firefox-companion-setup__connection-flow {
@@ -394,14 +428,17 @@
   }
 
   .firefox-companion-setup__connection-arrow {
-    line-height: 0.8;
+    line-height: 1;
     text-align: center;
     transform: rotate(90deg);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .firefox-companion-setup__download {
+  .firefox-companion-setup__download,
+  .firefox-companion-setup__copy,
+  .firefox-companion-setup__retry,
+  .firefox-companion-setup__guide {
     transition: none;
   }
 }

--- a/extension/codex-sidepanel/firefox-companion-setup.js
+++ b/extension/codex-sidepanel/firefox-companion-setup.js
@@ -33,22 +33,15 @@ function appendElement(document, parent, tagName, className, text) {
   return element;
 }
 
-function appendTerminalMark(document, parent) {
-  const mark = appendElement(document, parent, "div", "firefox-companion-setup__mark");
-  mark.setAttribute("aria-hidden", "true");
-  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  svg.setAttribute("viewBox", "0 0 24 24");
-  svg.setAttribute("fill", "none");
-  svg.setAttribute("stroke", "currentColor");
-  svg.setAttribute("stroke-width", "2");
-  svg.setAttribute("stroke-linecap", "round");
-  svg.setAttribute("stroke-linejoin", "round");
-  const prompt = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  prompt.setAttribute("d", "m5 7 5 5-5 5");
-  const cursor = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  cursor.setAttribute("d", "M12 17h7");
-  svg.append(prompt, cursor);
-  mark.append(svg);
+// The same Codex blossom mark the upstream onboarding surface renders.
+export const CODEX_LOGO_PATH = "codex-sidepanel/assets/app-D0g8sCle.png";
+
+function appendCodexLogo(document, parent, extension) {
+  const logo = appendElement(document, parent, "img", "firefox-companion-setup__logo");
+  logo.src = extension.runtime.getURL(CODEX_LOGO_PATH);
+  logo.alt = "";
+  logo.draggable = false;
+  logo.setAttribute("aria-hidden", "true");
 }
 
 function appendDownload(document, parent, { description, href, label, platform }) {
@@ -57,8 +50,9 @@ function appendDownload(document, parent, { description, href, label, platform }
   link.target = "_blank";
   link.rel = "noopener noreferrer";
   link.dataset.platform = platform;
-  appendElement(document, link, "strong", "", label);
-  appendElement(document, link, "span", "", description);
+  const text = appendElement(document, link, "div", "firefox-companion-setup__download-text");
+  appendElement(document, text, "strong", "", label);
+  appendElement(document, text, "span", "", description);
   return link;
 }
 
@@ -122,7 +116,7 @@ export function renderFirefoxCompanionSetup({
   const main = appendElement(document, root, "main", "firefox-companion-setup");
   const panel = appendElement(document, main, "section", "firefox-companion-setup__panel");
   panel.setAttribute("aria-labelledby", "firefox-companion-setup-title");
-  appendTerminalMark(document, panel);
+  appendCodexLogo(document, panel, extension);
   appendElement(document, panel, "p", "firefox-companion-setup__eyebrow", "One-time Firefox setup");
   const title = appendElement(document, panel, "h1", "firefox-companion-setup__title", "Enable the Codex connection");
   title.id = "firefox-companion-setup-title";

--- a/extension/codex-sidepanel/firefox-companion-setup.js
+++ b/extension/codex-sidepanel/firefox-companion-setup.js
@@ -1,0 +1,292 @@
+const NATIVE_TRANSPORT_ERRORS = Object.freeze([
+  "Native host request codexRuntime/hello timed out",
+  "Codex Chrome native host is incompatible",
+  "Codex Chrome native host v2 manifest is missing",
+  "No compatible Codex app-server entry was found",
+  "No Codex app-server entry matches the required protocol version",
+  "Native transport is disconnected; reconnect is pending",
+  "Native transport disconnected",
+]);
+
+export function isFirefoxCompanionSetupError(text) {
+  return typeof text === "string" &&
+    NATIVE_TRANSPORT_ERRORS.some((message) => text.includes(message));
+}
+
+export function getFirefoxCompanionSetupDetails(version) {
+  const releaseBase =
+    `https://github.com/SunkenInTime/codex-computer-use-firefox-zen/releases/download/v${version}`;
+  return {
+    chromeSetupUrl: "https://learn.chatgpt.com/docs/chrome-extension#set-up-the-chrome-extension",
+    command: `npx --yes codex-firefox-bridge@${version} install`,
+    doctorCommand: `npx --yes codex-firefox-bridge@${version} doctor`,
+    macosUrl: `${releaseBase}/codex-firefox-bridge-${version}-macos-universal.pkg`,
+    windowsUrl: `${releaseBase}/codex-firefox-bridge-${version}-windows-x64-setup.exe`,
+  };
+}
+
+function appendElement(document, parent, tagName, className, text) {
+  const element = document.createElement(tagName);
+  if (className) element.className = className;
+  if (text != null) element.textContent = text;
+  parent.append(element);
+  return element;
+}
+
+function appendTerminalMark(document, parent) {
+  const mark = appendElement(document, parent, "div", "firefox-companion-setup__mark");
+  mark.setAttribute("aria-hidden", "true");
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  const prompt = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  prompt.setAttribute("d", "m5 7 5 5-5 5");
+  const cursor = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  cursor.setAttribute("d", "M12 17h7");
+  svg.append(prompt, cursor);
+  mark.append(svg);
+}
+
+function appendDownload(document, parent, { description, href, label, platform }) {
+  const link = appendElement(document, parent, "a", "firefox-companion-setup__download");
+  link.href = href;
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  link.dataset.platform = platform;
+  appendElement(document, link, "strong", "", label);
+  appendElement(document, link, "span", "", description);
+  return link;
+}
+
+function appendStep(document, parent, title, detail) {
+  const item = appendElement(document, parent, "li", "firefox-companion-setup__step");
+  appendElement(document, item, "strong", "", title);
+  appendElement(document, item, "span", "", detail);
+}
+
+function appendCopyCommand(document, parent, { command, statusText }) {
+  const commandRow = appendElement(document, parent, "div", "firefox-companion-setup__command-row");
+  const code = appendElement(document, commandRow, "code", "", command);
+  const copyButton = appendElement(document, commandRow, "button", "firefox-companion-setup__copy", "Copy");
+  copyButton.type = "button";
+  const copyStatus = appendElement(document, parent, "span", "firefox-companion-setup__sr-only", "");
+  copyStatus.setAttribute("role", "status");
+  copyStatus.setAttribute("aria-live", "polite");
+  copyButton.addEventListener("click", async () => {
+    try {
+      if (globalThis.navigator.clipboard?.writeText == null) throw new Error("Clipboard unavailable");
+      await globalThis.navigator.clipboard.writeText(command);
+      copyButton.textContent = "Copied";
+      copyStatus.textContent = statusText;
+      globalThis.setTimeout(() => {
+        copyButton.textContent = "Copy";
+      }, 1600);
+    } catch {
+      const range = document.createRange();
+      range.selectNodeContents(code);
+      document.getSelection()?.removeAllRanges();
+      document.getSelection()?.addRange(range);
+      copyButton.textContent = "Selected";
+      copyStatus.textContent = `${statusText} selected`;
+    }
+  });
+}
+
+function appendConnectionNode(document, parent, title, detail) {
+  const node = appendElement(document, parent, "div", "firefox-companion-setup__connection-node");
+  node.setAttribute("role", "listitem");
+  appendElement(document, node, "strong", "", title);
+  appendElement(document, node, "span", "", detail);
+}
+
+function appendConnectionArrow(document, parent) {
+  const arrow = appendElement(document, parent, "span", "firefox-companion-setup__connection-arrow", "→");
+  arrow.setAttribute("aria-hidden", "true");
+}
+
+export function renderFirefoxCompanionSetup({
+  extension,
+  root,
+  reload = () => globalThis.location.reload(),
+}) {
+  const document = root.ownerDocument;
+  const version = extension.runtime.getManifest().version;
+  const details = getFirefoxCompanionSetupDetails(version);
+  root.replaceChildren();
+  root.dataset.firefoxCompanionSetup = "true";
+
+  const main = appendElement(document, root, "main", "firefox-companion-setup");
+  const panel = appendElement(document, main, "section", "firefox-companion-setup__panel");
+  panel.setAttribute("aria-labelledby", "firefox-companion-setup-title");
+  appendTerminalMark(document, panel);
+  appendElement(document, panel, "p", "firefox-companion-setup__eyebrow", "One-time Firefox setup");
+  const title = appendElement(document, panel, "h1", "firefox-companion-setup__title", "Enable the Codex connection");
+  title.id = "firefox-companion-setup-title";
+  appendElement(
+    document,
+    panel,
+    "p",
+    "firefox-companion-setup__lede",
+    "The sidebar could not reach the local Codex transport. Complete the two-part setup below: register OpenAI's native host through the official Chrome integration, then install the Firefox companion.",
+  );
+
+  const connection = appendElement(document, panel, "section", "firefox-companion-setup__connection");
+  appendElement(document, connection, "p", "firefox-companion-setup__option-label", "How the connection works");
+  const flow = appendElement(document, connection, "div", "firefox-companion-setup__connection-flow");
+  flow.setAttribute("role", "list");
+  flow.setAttribute("aria-label", "Firefox to Codex connection path");
+  appendConnectionNode(document, flow, "Firefox", "extension");
+  appendConnectionArrow(document, flow);
+  appendConnectionNode(document, flow, "Firefox", "companion");
+  appendConnectionArrow(document, flow);
+  appendConnectionNode(document, flow, "OpenAI", "native host");
+  appendConnectionArrow(document, flow);
+  appendConnectionNode(document, flow, "ChatGPT", "or Codex");
+
+  const prerequisite = appendElement(document, panel, "section", "firefox-companion-setup__prerequisite");
+  appendElement(document, prerequisite, "p", "firefox-companion-setup__option-label", "Required first");
+  appendElement(document, prerequisite, "h2", "", "Set up the official Chrome integration");
+  appendElement(
+    document,
+    prerequisite,
+    "p",
+    "firefox-companion-setup__muted",
+    "The Firefox companion depends on the OpenAI native host registered by the desktop app's Chrome plugin setup.",
+  );
+  const chromeSteps = appendElement(document, prerequisite, "ol", "firefox-companion-setup__compact-steps");
+  appendElement(document, chromeSteps, "li", "", "Install Google Chrome temporarily if it is not already installed.");
+  appendElement(document, chromeSteps, "li", "", "In the ChatGPT or Codex desktop app, open Plugins → Chrome and complete setup.");
+  appendElement(document, chromeSteps, "li", "", "Open Chrome once and confirm the ChatGPT side chat loads.");
+  const chromeGuide = appendElement(document, prerequisite, "a", "firefox-companion-setup__text-link", "Open the official Chrome setup guide ↗");
+  chromeGuide.href = details.chromeSetupUrl;
+  chromeGuide.target = "_blank";
+  chromeGuide.rel = "noopener noreferrer";
+  appendElement(
+    document,
+    prerequisite,
+    "p",
+    "firefox-companion-setup__note",
+    "Chrome does not need to become your default browser or remain open, but the official Chrome integration must remain installed.",
+  );
+
+  appendElement(document, panel, "h2", "firefox-companion-setup__section-title", "Install the Firefox companion");
+  appendElement(
+    document,
+    panel,
+    "p",
+    "firefox-companion-setup__section-copy",
+    "This local bridge connects Firefox to the native host you registered above. It runs only while Codex is connected and does not operate a remote service.",
+  );
+
+  const downloads = appendElement(document, panel, "div", "firefox-companion-setup__downloads");
+  downloads.setAttribute("aria-label", "Companion downloads");
+  const windows = appendDownload(document, downloads, {
+    description: "Per-user setup · Windows x64",
+    href: details.windowsUrl,
+    label: "Install for Windows",
+    platform: "win",
+  });
+  const macos = appendDownload(document, downloads, {
+    description: "Universal package · Apple Silicon and Intel",
+    href: details.macosUrl,
+    label: "Install for macOS",
+    platform: "mac",
+  });
+
+  const developer = appendElement(document, panel, "section", "firefox-companion-setup__developer");
+  appendElement(document, developer, "p", "firefox-companion-setup__option-label", "Developer path");
+  appendElement(document, developer, "h2", "", "Install with npm");
+  appendElement(
+    document,
+    developer,
+    "p",
+    "firefox-companion-setup__muted",
+    "This installs and registers the same bridge for your user account.",
+  );
+  appendCopyCommand(document, developer, {
+    command: details.command,
+    statusText: "npm install command copied",
+  });
+
+  const steps = appendElement(document, panel, "ol", "firefox-companion-setup__steps");
+  appendStep(document, steps, "Restart the desktop app", "Open or restart ChatGPT or Codex after both local pieces are installed.");
+  appendStep(document, steps, "Reopen the sidebar", "Close this Firefox sidebar, open it again, and choose Try again below.");
+
+  const diagnostics = appendElement(document, panel, "section", "firefox-companion-setup__diagnostics");
+  appendElement(document, diagnostics, "p", "firefox-companion-setup__option-label", "Still disconnected?");
+  appendElement(document, diagnostics, "h2", "", "Check both local pieces");
+  appendElement(
+    document,
+    diagnostics,
+    "p",
+    "firefox-companion-setup__muted",
+    "The doctor command reports whether the Firefox companion and its required OpenAI native host are both available.",
+  );
+  appendCopyCommand(document, diagnostics, {
+    command: details.doctorCommand,
+    statusText: "doctor command copied",
+  });
+
+  const help = appendElement(document, panel, "details", "firefox-companion-setup__help");
+  appendElement(document, help, "summary", "", "Why is this needed?");
+  appendElement(
+    document,
+    help,
+    "p",
+    "",
+    "The Chrome plugin setup registers the local com.openai.codexextension host. Firefox extensions cannot reuse a host registered only for a Chrome extension, so the companion crosses that browser and operating-system boundary and relays Firefox to the official local Codex host.",
+  );
+
+  const actions = appendElement(document, panel, "div", "firefox-companion-setup__actions");
+  const retry = appendElement(document, actions, "button", "firefox-companion-setup__retry", "Try again");
+  retry.type = "button";
+  retry.addEventListener("click", reload);
+  const guide = appendElement(document, actions, "a", "firefox-companion-setup__guide", "Open full setup guide");
+  guide.href = extension.runtime.getURL("companion-required.html");
+  guide.target = "_blank";
+  guide.rel = "noopener noreferrer";
+
+  extension.runtime.getPlatformInfo().then(({ os }) => {
+    const recommended = os === "win" ? windows : os === "mac" ? macos : null;
+    if (recommended != null) {
+      recommended.classList.add("firefox-companion-setup__download--recommended");
+      const label = recommended.querySelector("strong")?.textContent ?? "Platform installer";
+      recommended.setAttribute("aria-label", `${label} — recommended for this device`);
+    }
+  }).catch(() => {});
+
+  return main;
+}
+
+export function installFirefoxCompanionSetup({
+  extension,
+  root = globalThis.document?.querySelector("#root"),
+  reload,
+}) {
+  if (root == null) {
+    throw new Error("Codex side panel root not found while installing companion setup guidance.");
+  }
+
+  const renderIfNeeded = () => {
+    if (root.dataset.firefoxCompanionSetup === "true") return true;
+    if (!isFirefoxCompanionSetupError(root.textContent)) return false;
+    const setupRoot = root.ownerDocument.createElement("div");
+    setupRoot.className = "firefox-companion-setup-root";
+    root.hidden = true;
+    root.dataset.firefoxCompanionSetup = "true";
+    root.after(setupRoot);
+    renderFirefoxCompanionSetup({ extension, root: setupRoot, reload });
+    return true;
+  };
+
+  if (renderIfNeeded()) return () => {};
+  const observer = new MutationObserver(() => {
+    if (renderIfNeeded()) observer.disconnect();
+  });
+  observer.observe(root, { childList: true, characterData: true, subtree: true });
+  return () => observer.disconnect();
+}

--- a/extension/codex-sidepanel/firefox-sidebar-bootstrap.js
+++ b/extension/codex-sidepanel/firefox-sidebar-bootstrap.js
@@ -1,4 +1,5 @@
 import { ensureFirefoxHostAccess } from "./firefox-host-access.js";
+import { installFirefoxCompanionSetup } from "./firefox-companion-setup.js";
 
 const extension = globalThis.browser ?? globalThis.chrome;
 const isFirefox = /Firefox\//.test(navigator.userAgent);
@@ -6,6 +7,7 @@ const isFirefox = /Firefox\//.test(navigator.userAgent);
 if (isFirefox && !await ensureFirefoxHostAccess({ extension })) {
   // The permission prompt owns the sidebar until Firefox grants website access.
 } else if (isFirefox) {
+  installFirefoxCompanionSetup({ extension });
   // The Firefox port supplies open-tab mentions directly through its own
   // privileged runtime. The inherited UI otherwise waits for a Chrome-only
   // plugin-discovery flag and discards valid Firefox tab candidates.

--- a/extension/codex-sidepanel/index.html
+++ b/extension/codex-sidepanel/index.html
@@ -40,6 +40,7 @@
     <link rel="stylesheet" crossorigin href="./assets/progression-donut-BTleCTWE.css">
     <link rel="stylesheet" crossorigin href="./assets/app-window-9qbkMWnL.css">
     <link rel="stylesheet" crossorigin href="./assets/chrome-extension-sidepanel-Bw4Xnpx7.css">
+    <link rel="stylesheet" href="./firefox-companion-setup.css">
   </head>
   <body>
     <div id="root"></div>

--- a/extension/companion-required.css
+++ b/extension/companion-required.css
@@ -1,8 +1,33 @@
+/*
+ * Matches the sidepanel's onboarding surface styling: flat light/dark
+ * surface, centered column, blossom mark, heading-lg title, rounded-full
+ * buttons, and subtle bordered cards.
+ */
 :root {
   color-scheme: light dark;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: #f4f1ea;
-  color: #171717;
+  --surface: #fff;
+  --foreground: #0d0d0d;
+  --secondary: color-mix(in srgb, var(--foreground) 65%, transparent);
+  --tertiary: color-mix(in srgb, var(--foreground) 45%, transparent);
+  --border: color-mix(in srgb, var(--foreground) 10%, transparent);
+  --border-heavy: color-mix(in srgb, var(--foreground) 15%, transparent);
+  --surface-secondary: color-mix(in srgb, var(--foreground) 5%, transparent);
+  --button-bg: #0d0d0d;
+  --button-fg: #fff;
+  background: var(--surface);
+  color: var(--foreground);
+  font-family: "OpenAI Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --surface: #212121;
+    --foreground: #f4f4f4;
+    --button-bg: #f4f4f4;
+    --button-fg: #212121;
+  }
 }
 
 [hidden] {
@@ -12,151 +37,73 @@
 body {
   min-height: 100vh;
   margin: 0;
-  display: grid;
-  place-items: center;
-  background:
-    radial-gradient(circle at 20% 0%, rgba(255, 255, 255, 0.95), transparent 38rem),
-    #f4f1ea;
 }
 
 main {
   box-sizing: border-box;
-  width: min(42rem, calc(100% - 2rem));
-  margin: 3rem auto;
-  padding: clamp(2rem, 6vw, 4rem);
-  border: 1px solid rgba(23, 23, 23, 0.12);
-  border-radius: 1.5rem;
-  background: rgba(255, 255, 255, 0.72);
-  box-shadow: 0 1.5rem 5rem rgba(55, 45, 30, 0.12);
-  backdrop-filter: blur(1rem);
+  width: min(100%, 560px);
+  margin: 0 auto;
+  padding: 56px 24px 64px;
 }
 
 .mark {
-  width: 3rem;
-  height: 3rem;
-  border-radius: 0.9rem;
-  object-fit: cover;
+  display: block;
+  width: 72px;
+  height: 72px;
+  margin: 0 auto;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 .eyebrow {
-  margin: 2rem 0 0.55rem;
-  color: #9a4f16;
-  font-size: 0.78rem;
-  font-weight: 750;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  margin: 20px 0 0;
+  color: var(--tertiary);
+  font-size: 12px;
+  font-weight: 500;
+  text-align: center;
 }
 
 h1 {
-  margin: 0;
-  font-size: clamp(2.15rem, 7vw, 3.65rem);
-  line-height: 0.98;
-  letter-spacing: -0.055em;
+  margin: 4px auto 0;
+  max-width: 360px;
+  font-size: 24px;
+  font-weight: 500;
+  letter-spacing: -0.3px;
+  line-height: 1.2;
+  text-align: center;
 }
 
 .lede {
-  margin: 1.5rem 0 2rem;
-  color: #55504a;
-  font-size: 1.08rem;
-  line-height: 1.6;
-}
-
-.downloads {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.8rem;
-}
-
-.downloads.single {
-  grid-template-columns: 1fr;
-}
-
-.version-status {
-  margin: 0 0 1.25rem;
-  padding: 1rem;
-  border: 1px solid rgba(185, 28, 28, 0.28);
-  border-radius: 0.9rem;
-  background: rgba(254, 226, 226, 0.72);
-}
-
-.version-status h2 {
-  margin: 0 0 0.8rem;
-  font-size: 0.82rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.version-status dl {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem;
-  margin: 0;
-}
-
-.version-status dl div {
-  padding: 0.75rem;
-  border-radius: 0.65rem;
-  background: rgba(255, 255, 255, 0.68);
-}
-
-.version-status dt {
-  color: #716b64;
-  font-size: 0.72rem;
-}
-
-.version-status dd {
-  margin: 0.2rem 0 0;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 0.92rem;
-  font-weight: 700;
-}
-
-.download {
-  padding: 1rem;
-  border: 1px solid rgba(23, 23, 23, 0.14);
-  border-radius: 0.9rem;
-  color: inherit;
-  text-decoration: none;
-  transition: transform 140ms ease, border-color 140ms ease, background 140ms ease;
-}
-
-.download:hover,
-.download.recommended {
-  border-color: #171717;
-  background: #fff;
-  transform: translateY(-2px);
-}
-
-.download strong,
-.download span {
-  display: block;
-}
-
-.download span {
-  margin-top: 0.35rem;
-  color: #716b64;
-  font-size: 0.8rem;
+  margin: 12px auto 28px;
+  max-width: 420px;
+  color: var(--secondary);
+  font-size: 14px;
+  line-height: 1.5;
+  text-align: center;
 }
 
 .connection,
 .prerequisite,
 .developer-install,
 .doctor,
-.why {
-  margin-top: 1.25rem;
-  padding: 1.1rem;
-  border: 1px solid rgba(23, 23, 23, 0.12);
-  border-radius: 0.9rem;
-  background: rgba(255, 255, 255, 0.45);
+.why,
+.version-status {
+  margin-top: 12px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
 }
 
 .connection h2,
 .prerequisite h2,
 .developer-install h2,
 .doctor h2,
-.why h2 {
+.why h2,
+.version-status h2 {
   margin: 0;
-  font-size: 1rem;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
 }
 
 .connection p,
@@ -164,130 +111,243 @@ h1 {
 .developer-install p,
 .doctor p,
 .why p {
-  margin: 0.5rem 0 0;
-  color: #55504a;
-  font-size: 0.88rem;
-  line-height: 1.55;
+  margin: 4px 0 0;
+  color: var(--secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.option-label {
+  margin: 0 0 2px !important;
+  color: var(--tertiary) !important;
+  font-size: 12px !important;
+  font-weight: 500;
 }
 
 .connection-flow {
   display: flex;
   align-items: center;
-  gap: 0.45rem;
-  margin-top: 1rem;
+  gap: 6px;
+  margin-top: 12px;
 }
 
 .connection-flow span {
   min-width: 0;
   flex: 1;
-  padding: 0.75rem 0.45rem;
-  border-radius: 0.65rem;
-  background: rgba(255, 255, 255, 0.68);
-  font-size: 0.7rem;
-  font-weight: 650;
-  line-height: 1.25;
+  padding: 8px 6px;
+  border-radius: 10px;
+  background: var(--surface-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.3;
   text-align: center;
 }
 
 .connection-flow b {
-  color: #77716a;
-  font-size: 0.8rem;
-}
-
-.prerequisite {
-  border-color: rgba(154, 79, 22, 0.32);
-  background: rgba(215, 129, 55, 0.08);
+  flex: none;
+  color: var(--tertiary);
+  font-size: 12px;
+  font-weight: 400;
 }
 
 .compact-steps {
-  margin: 1rem 0;
-  padding-left: 1.25rem;
-  color: #55504a;
-  font-size: 0.84rem;
-  line-height: 1.6;
+  display: grid;
+  gap: 6px;
+  margin: 10px 0;
+  padding-left: 18px;
+  color: var(--secondary);
+  font-size: 13px;
+  line-height: 1.5;
 }
 
 .text-link {
   color: inherit;
-  font-size: 0.82rem;
-  font-weight: 650;
-  text-underline-offset: 0.2rem;
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration-color: var(--tertiary);
+  text-underline-offset: 3px;
 }
 
 .note {
-  margin-top: 1rem !important;
-  padding-top: 1rem;
-  border-top: 1px solid rgba(23, 23, 23, 0.1);
-  font-size: 0.78rem !important;
+  margin: 12px 0 0 !important;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  color: var(--tertiary) !important;
+  font-size: 12px !important;
+  line-height: 1.5;
+}
+
+.version-status dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 12px 0 0;
+}
+
+.version-status dl div {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.version-status dt {
+  color: var(--tertiary);
+  font-size: 12px;
+}
+
+.version-status dd {
+  margin: 2px 0 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .bridge-intro {
-  margin-top: 1.75rem;
+  margin-top: 28px;
 }
 
 .bridge-intro h2 {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.1px;
 }
 
 .bridge-intro p:not(.option-label) {
-  margin: 0.5rem 0 1rem;
-  color: #55504a;
-  font-size: 0.88rem;
-  line-height: 1.55;
+  margin: 4px 0 12px;
+  color: var(--secondary);
+  font-size: 13px;
+  line-height: 1.5;
 }
 
-.option-label {
-  color: #9a4f16 !important;
-  font-size: 0.7rem !important;
-  font-weight: 750;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+.downloads {
+  display: grid;
+  gap: 8px;
+}
+
+.downloads + .downloads,
+section.downloads {
+  margin-top: 12px;
+}
+
+.download {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: inherit;
+  text-decoration: none;
+  transition: background 140ms ease;
+}
+
+.download:hover {
+  background: var(--surface-secondary);
+}
+
+.download.recommended {
+  border-color: var(--border-heavy);
+  background: var(--surface-secondary);
+}
+
+.download-text {
+  min-width: 0;
+  flex: 1;
+}
+
+.download strong,
+.download-text span {
+  display: block;
+}
+
+.download strong {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.download-text span {
+  margin-top: 2px;
+  color: var(--tertiary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.download::after {
+  content: "↓";
+  flex: none;
+  color: var(--tertiary);
+  font-size: 14px;
 }
 
 .command-row {
   display: flex;
-  gap: 0.5rem;
-  margin-top: 1rem;
+  gap: 8px;
+  margin-top: 12px;
 }
 
 .command-row code {
   min-width: 0;
   flex: 1;
   overflow-x: auto;
-  padding: 0.7rem;
-  border-radius: 0.55rem;
-  background: #171717;
-  color: #f7f3ec;
-  font-size: 0.78rem;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--surface-secondary);
+  color: inherit;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
   white-space: nowrap;
 }
 
 .command-row button {
-  border: 1px solid rgba(23, 23, 23, 0.2);
-  border-radius: 0.55rem;
-  padding: 0 0.9rem;
+  min-width: 64px;
+  padding: 0 14px;
+  border: 1px solid var(--border-heavy);
+  border-radius: 9999px;
   background: transparent;
   color: inherit;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
+  transition: background 140ms ease;
+}
+
+.command-row button:hover {
+  background: var(--surface-secondary);
 }
 
 .finish-steps {
-  margin: 2rem 0;
-  padding-left: 1.25rem;
-  line-height: 1.7;
+  display: grid;
+  gap: 6px;
+  margin: 24px 0;
+  padding-left: 18px;
+  color: var(--secondary);
+  font-size: 13px;
+  line-height: 1.5;
 }
 
 .footnote {
-  margin: 0;
-  color: #77716a;
-  font-size: 0.78rem;
-  line-height: 1.55;
+  margin: 24px 0 0;
+  color: var(--tertiary);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: center;
 }
 
-@media (max-width: 36rem) {
-  .downloads {
-    grid-template-columns: 1fr;
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid #0285ff;
+  outline-offset: 2px;
+}
+
+@media (max-width: 480px) {
+  main {
+    padding: 40px 16px 48px;
   }
 
   .connection-flow {
@@ -296,74 +356,19 @@ h1 {
   }
 
   .connection-flow b {
-    line-height: 0.8;
+    line-height: 1;
+    text-align: center;
     transform: rotate(90deg);
+  }
+
+  .version-status dl {
+    grid-template-columns: 1fr;
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    background: #171614;
-    color: #f7f3ec;
-  }
-
-  body {
-    background:
-      radial-gradient(circle at 20% 0%, rgba(70, 62, 49, 0.5), transparent 34rem),
-      #171614;
-  }
-
-  main {
-    border-color: rgba(255, 255, 255, 0.12);
-    background: rgba(32, 30, 27, 0.8);
-  }
-
-  .lede,
-  .download span,
-  .compact-steps,
-  .connection p,
-  .prerequisite p,
-  .bridge-intro p:not(.option-label),
-  .developer-install p,
-  .doctor p,
-  .why p,
-  .footnote {
-    color: #bbb3a8;
-  }
-
-  .download {
-    border-color: rgba(255, 255, 255, 0.15);
-  }
-
-  .connection,
-  .prerequisite,
-  .developer-install,
-  .doctor,
-  .why,
-  .version-status {
-    border-color: rgba(255, 255, 255, 0.12);
-    background: rgba(255, 255, 255, 0.03);
-  }
-
-  .version-status dl div {
-    background: rgba(255, 255, 255, 0.05);
-  }
-
-  .connection-flow span {
-    background: rgba(255, 255, 255, 0.05);
-  }
-
-  .note {
-    border-top-color: rgba(255, 255, 255, 0.1);
-  }
-
+@media (prefers-reduced-motion: reduce) {
+  .download,
   .command-row button {
-    border-color: rgba(255, 255, 255, 0.2);
-  }
-
-  .download:hover,
-  .download.recommended {
-    border-color: #f7f3ec;
-    background: #282521;
+    transition: none;
   }
 }

--- a/extension/companion-required.css
+++ b/extension/companion-required.css
@@ -138,7 +138,10 @@ h1 {
   font-size: 0.8rem;
 }
 
+.connection,
+.prerequisite,
 .developer-install,
+.doctor,
 .why {
   margin-top: 1.25rem;
   padding: 1.1rem;
@@ -147,15 +150,88 @@ h1 {
   background: rgba(255, 255, 255, 0.45);
 }
 
+.connection h2,
+.prerequisite h2,
 .developer-install h2,
+.doctor h2,
 .why h2 {
   margin: 0;
   font-size: 1rem;
 }
 
+.connection p,
+.prerequisite p,
 .developer-install p,
+.doctor p,
 .why p {
   margin: 0.5rem 0 0;
+  color: #55504a;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.connection-flow {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 1rem;
+}
+
+.connection-flow span {
+  min-width: 0;
+  flex: 1;
+  padding: 0.75rem 0.45rem;
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.68);
+  font-size: 0.7rem;
+  font-weight: 650;
+  line-height: 1.25;
+  text-align: center;
+}
+
+.connection-flow b {
+  color: #77716a;
+  font-size: 0.8rem;
+}
+
+.prerequisite {
+  border-color: rgba(154, 79, 22, 0.32);
+  background: rgba(215, 129, 55, 0.08);
+}
+
+.compact-steps {
+  margin: 1rem 0;
+  padding-left: 1.25rem;
+  color: #55504a;
+  font-size: 0.84rem;
+  line-height: 1.6;
+}
+
+.text-link {
+  color: inherit;
+  font-size: 0.82rem;
+  font-weight: 650;
+  text-underline-offset: 0.2rem;
+}
+
+.note {
+  margin-top: 1rem !important;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(23, 23, 23, 0.1);
+  font-size: 0.78rem !important;
+}
+
+.bridge-intro {
+  margin-top: 1.75rem;
+}
+
+.bridge-intro h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.bridge-intro p:not(.option-label) {
+  margin: 0.5rem 0 1rem;
   color: #55504a;
   font-size: 0.88rem;
   line-height: 1.55;
@@ -196,7 +272,7 @@ h1 {
   cursor: pointer;
 }
 
-ol {
+.finish-steps {
   margin: 2rem 0;
   padding-left: 1.25rem;
   line-height: 1.7;
@@ -212,6 +288,16 @@ ol {
 @media (max-width: 36rem) {
   .downloads {
     grid-template-columns: 1fr;
+  }
+
+  .connection-flow {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .connection-flow b {
+    line-height: 0.8;
+    transform: rotate(90deg);
   }
 }
 
@@ -234,7 +320,12 @@ ol {
 
   .lede,
   .download span,
+  .compact-steps,
+  .connection p,
+  .prerequisite p,
+  .bridge-intro p:not(.option-label),
   .developer-install p,
+  .doctor p,
   .why p,
   .footnote {
     color: #bbb3a8;
@@ -244,7 +335,10 @@ ol {
     border-color: rgba(255, 255, 255, 0.15);
   }
 
+  .connection,
+  .prerequisite,
   .developer-install,
+  .doctor,
   .why,
   .version-status {
     border-color: rgba(255, 255, 255, 0.12);
@@ -253,6 +347,14 @@ ol {
 
   .version-status dl div {
     background: rgba(255, 255, 255, 0.05);
+  }
+
+  .connection-flow span {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  .note {
+    border-top-color: rgba(255, 255, 255, 0.1);
   }
 
   .command-row button {

--- a/extension/companion-required.html
+++ b/extension/companion-required.html
@@ -12,10 +12,40 @@
       <p id="eyebrow" class="eyebrow">One-time setup</p>
       <h1 id="page-title">Enable the Codex connection</h1>
       <p id="page-lede" class="lede">
-        Firefox needs a small local companion to connect this extension to your
-        installed Codex host. It runs only while Codex is connected and does not
-        operate a remote service.
+        This connection has two local pieces: OpenAI's native host, registered
+        through the official Chrome integration, and the Firefox companion that
+        relays this extension to that host.
       </p>
+      <section id="connection-explanation" class="connection" aria-labelledby="connection-title">
+        <p class="option-label">How the connection works</p>
+        <h2 id="connection-title">Firefox hands off to the local Codex host</h2>
+        <div class="connection-flow" aria-label="Firefox extension to Codex connection path">
+          <span>Firefox extension</span><b aria-hidden="true">→</b>
+          <span>Firefox companion</span><b aria-hidden="true">→</b>
+          <span>OpenAI native host</span><b aria-hidden="true">→</b>
+          <span>ChatGPT or Codex</span>
+        </div>
+      </section>
+      <section id="chrome-prerequisite" class="prerequisite" aria-labelledby="prerequisite-title">
+        <p class="option-label">Required first</p>
+        <h2 id="prerequisite-title">Set up the official Chrome integration</h2>
+        <p>
+          The Firefox companion depends on the OpenAI native host registered by
+          the desktop app's Chrome plugin setup.
+        </p>
+        <ol class="compact-steps">
+          <li>Install Google Chrome temporarily if it is not already installed.</li>
+          <li>In the ChatGPT or Codex desktop app, open <strong>Plugins → Chrome</strong> and complete setup.</li>
+          <li>Open Chrome once and confirm the ChatGPT side chat loads.</li>
+        </ol>
+        <a class="text-link" href="https://learn.chatgpt.com/docs/chrome-extension#set-up-the-chrome-extension">
+          Open the official Chrome setup guide ↗
+        </a>
+        <p class="note">
+          Chrome does not need to become your default browser or remain open,
+          but the official Chrome integration must remain installed.
+        </p>
+      </section>
       <section id="version-status" class="version-status" aria-labelledby="version-status-title" hidden>
         <h2 id="version-status-title">Installed versions</h2>
         <dl>
@@ -35,6 +65,15 @@
           <span>Install the latest signed build from Mozilla Add-ons</span>
         </a>
       </section>
+      <div class="bridge-intro">
+        <p class="option-label">Then</p>
+        <h2>Install the Firefox companion</h2>
+        <p>
+          This local bridge connects Firefox to the native host registered
+          above. It runs only while Codex is connected and does not operate a
+          remote service.
+        </p>
+      </div>
       <section id="bridge-downloads" class="downloads" aria-label="Companion downloads">
         <a id="windows-download" class="download" href="#">
           <strong>Install for Windows</strong>
@@ -59,11 +98,23 @@
           <button id="copy-npm-command" type="button">Copy</button>
         </div>
       </section>
-      <ol>
-        <li id="setup-step-one">Choose a platform installer or the npm command above.</li>
-        <li id="setup-step-two">Keep the existing Codex Chrome integration installed.</li>
-        <li id="setup-step-three">Close this page and reopen the Codex sidebar.</li>
+      <ol class="finish-steps">
+        <li id="setup-step-one">Install the Firefox companion with a platform installer or the npm command above.</li>
+        <li id="setup-step-two">Restart the ChatGPT or Codex desktop app after both local pieces are installed.</li>
+        <li id="setup-step-three">Close this page, reopen the Codex sidebar, and try again.</li>
       </ol>
+      <section class="doctor" aria-labelledby="doctor-title">
+        <p class="option-label">Still disconnected?</p>
+        <h2 id="doctor-title">Check both local pieces</h2>
+        <p>
+          This reports whether the Firefox companion and its required OpenAI
+          native host are both available.
+        </p>
+        <div class="command-row">
+          <code id="doctor-command">npx --yes codex-firefox-bridge@VERSION doctor</code>
+          <button id="copy-doctor-command" type="button">Copy</button>
+        </div>
+      </section>
       <section class="why" aria-labelledby="why-title">
         <h2 id="why-title">Why is this needed?</h2>
         <p>

--- a/extension/companion-required.html
+++ b/extension/companion-required.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <main>
-      <img class="mark" src="images/firefox-zen-icon96.png" alt="">
+      <img class="mark" src="codex-sidepanel/assets/app-D0g8sCle.png" alt="" draggable="false">
       <p id="eyebrow" class="eyebrow">One-time setup</p>
       <h1 id="page-title">Enable the Codex connection</h1>
       <p id="page-lede" class="lede">
@@ -61,8 +61,10 @@
       </section>
       <section id="extension-update-section" class="downloads single" aria-label="Extension update" hidden>
         <a class="download recommended" href="https://addons.mozilla.org/firefox/addon/codex-computer-use-for-zen/">
-          <strong>Update the Firefox extension</strong>
-          <span>Install the latest signed build from Mozilla Add-ons</span>
+          <span class="download-text">
+            <strong>Update the Firefox extension</strong>
+            <span>Install the latest signed build from Mozilla Add-ons</span>
+          </span>
         </a>
       </section>
       <div class="bridge-intro">
@@ -76,12 +78,16 @@
       </div>
       <section id="bridge-downloads" class="downloads" aria-label="Companion downloads">
         <a id="windows-download" class="download" href="#">
-          <strong>Install for Windows</strong>
-          <span>Per-user setup · Windows x64</span>
+          <span class="download-text">
+            <strong>Install for Windows</strong>
+            <span>Per-user setup · Windows x64</span>
+          </span>
         </a>
         <a id="macos-download" class="download" href="#">
-          <strong>Install for macOS</strong>
-          <span>Universal package · Apple Silicon and Intel</span>
+          <span class="download-text">
+            <strong>Install for macOS</strong>
+            <span>Universal package · Apple Silicon and Intel</span>
+          </span>
         </a>
       </section>
       <section id="developer-install" class="developer-install" aria-labelledby="developer-install-title">

--- a/extension/companion-required.js
+++ b/extension/companion-required.js
@@ -8,9 +8,12 @@
   const macos = document.querySelector("#macos-download");
   const npmCommand = document.querySelector("#npm-command");
   const copyNpmCommand = document.querySelector("#copy-npm-command");
+  const doctorCommand = document.querySelector("#doctor-command");
+  const copyDoctorCommand = document.querySelector("#copy-doctor-command");
   const parameters = new URLSearchParams(location.search);
   const mismatch = parameters.get("reason") === "version-mismatch";
   const command = `npx --yes codex-firefox-bridge@${version} install`;
+  const doctor = `npx --yes codex-firefox-bridge@${version} doctor`;
 
   if (mismatch) {
     const bridgeVersion = parameters.get("bridgeVersion") ?? "unknown";
@@ -28,6 +31,8 @@
       : `v${bridgeVersion}`;
     document.querySelector("#version-status").hidden = false;
     document.querySelector("#extension-update-section").hidden = !extensionIsOlder;
+    document.querySelector("#connection-explanation").hidden = true;
+    document.querySelector("#chrome-prerequisite").hidden = true;
     document.querySelector("#setup-step-one").textContent = extensionIsOlder
       ? "Install the latest signed extension, or choose a matching bridge installer below."
       : "Choose a platform installer or run the exact npm command above.";
@@ -40,18 +45,9 @@
   macos.href =
     `${releaseBase}/codex-firefox-bridge-${version}-macos-universal.pkg`;
   npmCommand.textContent = command;
-  copyNpmCommand.addEventListener("click", async () => {
-    try {
-      await navigator.clipboard.writeText(command);
-      copyNpmCommand.textContent = "Copied";
-      setTimeout(() => {
-        copyNpmCommand.textContent = "Copy";
-      }, 1600);
-    } catch {
-      window.getSelection()?.selectAllChildren(npmCommand);
-      copyNpmCommand.textContent = "Selected";
-    }
-  });
+  doctorCommand.textContent = doctor;
+  configureCopyButton(copyNpmCommand, npmCommand, command);
+  configureCopyButton(copyDoctorCommand, doctorCommand, doctor);
 
   browser.runtime.getPlatformInfo().then(({ os }) => {
     if (os === "win") {
@@ -60,6 +56,21 @@
       macos.classList.add("recommended");
     }
   }).catch(() => {});
+
+  function configureCopyButton(button, code, text) {
+    button.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(text);
+        button.textContent = "Copied";
+        setTimeout(() => {
+          button.textContent = "Copy";
+        }, 1600);
+      } catch {
+        window.getSelection()?.selectAllChildren(code);
+        button.textContent = "Selected";
+      }
+    });
+  }
 
   function compareVersions(left, right) {
     const leftParts = left.split(".").map(Number);

--- a/extension/firefox-compat.js
+++ b/extension/firefox-compat.js
@@ -172,19 +172,6 @@
       }
       firefox.action.setBadgeBackgroundColor({ color: "#d97706" }).catch(() => {});
       firefox.action.setBadgeText({ text: "SETUP" }).catch(() => {});
-      const storageKey = `companionSetupPromptShown:${firefox.runtime.getManifest().version}`;
-      firefox.storage.local.get(storageKey).then((stored) => {
-        if (stored[storageKey]) {
-          return;
-        }
-        return firefox.storage.local
-          .set({ [storageKey]: true })
-          .then(() =>
-            firefox.tabs.create({
-              url: firefox.runtime.getURL("companion-required.html"),
-            }),
-          );
-      }).catch(() => {});
     });
 
     const onMessage = {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "check": "node scripts/check-version.mjs && node scripts/verify-extension.mjs",
     "version:set": "node scripts/set-version.mjs",
-    "test": "npm run check && node tests/test-companion-required.mjs && node tests/test-sidepanel-focus-compat.mjs && node tests/test-sidepanel-host-access.mjs && node tests/test-sidepanel-bootstrap.mjs && node tests/test-chatgpt-feature-parity.mjs && node tests/test-firefox-compat.mjs && node tests/test-editing-assets.mjs && node tests/test-native-host.mjs",
+    "test": "npm run check && node tests/test-companion-required.mjs && node tests/test-sidepanel-focus-compat.mjs && node tests/test-sidepanel-host-access.mjs && node tests/test-sidepanel-bootstrap.mjs && node tests/test-sidepanel-companion-setup.mjs && node tests/test-chatgpt-feature-parity.mjs && node tests/test-firefox-compat.mjs && node tests/test-editing-assets.mjs && node tests/test-native-host.mjs",
     "package": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-extension.ps1"
   }
 }

--- a/scripts/verify-extension.mjs
+++ b/scripts/verify-extension.mjs
@@ -52,7 +52,13 @@ for (const contentScript of manifest.content_scripts ?? []) {
 }
 
 assert(existsInExtension(manifest.sidebar_action.default_panel), "The ChatGPT sidebar HTML is missing.");
-for (const setupFile of ["companion-required.html", "companion-required.css", "companion-required.js"]) {
+for (const setupFile of [
+  "companion-required.html",
+  "companion-required.css",
+  "companion-required.js",
+  "codex-sidepanel/firefox-companion-setup.css",
+  "codex-sidepanel/firefox-companion-setup.js",
+]) {
   assert(existsInExtension(setupFile), `Missing companion setup asset: ${setupFile}`);
 }
 new vm.Script(read("extension/companion-required.js"), { filename: "companion-required.js" });
@@ -61,6 +67,8 @@ assert(setupHtml.includes("codex-firefox-bridge@"), "The npm installation path i
 assert(setupHtml.includes("https://addons.mozilla.org/firefox/addon/codex-computer-use-for-zen/"), "The signed Firefox extension update path is missing from setup.");
 assert(setupHtml.includes('id="version-status"'), "The setup page cannot show installed version details.");
 assert(setupHtml.includes("Why is this needed?"), "The setup page must explain why the companion is required.");
+assert(setupHtml.includes("Plugins → Chrome"), "The setup page must explain how to register the OpenAI native host.");
+assert(setupHtml.includes("doctor-command"), "The setup page must include bridge diagnostics.");
 for (const size of ["16", "24", "32", "48", "64", "96", "128"]) {
   assert(size in manifest.icons, `Missing ${size}px icon declaration.`);
 }
@@ -74,8 +82,13 @@ for (const match of sidebarHtml.matchAll(/(?:src|href)="\.\/([^"?#]+)"/gu)) {
 }
 
 const compatibilitySource = read("extension/firefox-compat.js");
-assert(compatibilitySource.includes("companionSetupPromptShown:"), "Missing one-time companion setup guidance.");
 assert(compatibilitySource.includes("companionVersionMismatchPromptShown:"), "Missing bridge version mismatch guidance.");
+assert(!compatibilitySource.includes('tabs.create({\n              url: firefox.runtime.getURL("companion-required.html")'), "Companion setup must not open a surprise tab.");
+const sidebarSetupSource = read("extension/codex-sidepanel/firefox-companion-setup.js");
+assert(sidebarSetupSource.includes("Native transport disconnected"), "Sidebar setup must recognize a disconnected native transport.");
+assert(sidebarSetupSource.includes("Install for Windows"), "Sidebar setup is missing the Windows installer.");
+assert(sidebarSetupSource.includes("Install for macOS"), "Sidebar setup is missing the macOS installer.");
+assert(sidebarSetupSource.includes("Plugins → Chrome"), "Sidebar setup must explain the required OpenAI native-host registration.");
 const coreCdpMethods = [
   "DOM.describeNode",
   "DOM.getBoxModel",

--- a/tests/fixtures/sidebar-companion-setup.html
+++ b/tests/fixtures/sidebar-companion-setup.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en" data-codex-window-type="chrome-extension">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Firefox companion setup preview</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --color-token-main-surface-primary: #181818;
+        --color-token-foreground: #fff;
+        --color-token-text-secondary: rgba(255, 255, 255, 0.7);
+        --color-token-text-tertiary: rgba(255, 255, 255, 0.5);
+        --color-token-border: rgba(255, 255, 255, 0.08);
+        --color-token-border-heavy: rgba(255, 255, 255, 0.16);
+        --color-background-elevated-secondary: rgba(255, 255, 255, 0.03);
+        --color-background-button-secondary: rgba(255, 255, 255, 0.06);
+        --color-accent-orange: #fb6a22;
+        --color-border-focus: #339cff;
+        --gray-100: #ededed;
+        --gray-1000: #0d0d0d;
+        --radius-lg: 10px;
+        --radius-xl: 12px;
+        --radius-2xl: 16px;
+        --radius-3xl: 20px;
+      }
+      html, body, #root { height: 100%; margin: 0; }
+    </style>
+    <link rel="stylesheet" href="../../extension/codex-sidepanel/firefox-companion-setup.css">
+  </head>
+  <body>
+    <div id="root">Native transport disconnected</div>
+    <script type="module">
+      import { installFirefoxCompanionSetup } from "../../extension/codex-sidepanel/firefox-companion-setup.js";
+
+      const extension = {
+        runtime: {
+          getManifest: () => ({ version: "1.4.7" }),
+          getPlatformInfo: async () => ({ os: "win" }),
+          getURL: (path) => `../../extension/${path}`,
+        },
+      };
+      installFirefoxCompanionSetup({
+        extension,
+        root: document.querySelector("#root"),
+        reload: () => {},
+      });
+    </script>
+  </body>
+</html>

--- a/tests/test-companion-required.mjs
+++ b/tests/test-companion-required.mjs
@@ -6,8 +6,12 @@ const source = fs.readFileSync("extension/companion-required.js", "utf8");
 const elementIds = [
   "bridge-downloads",
   "bridge-version",
+  "chrome-prerequisite",
+  "connection-explanation",
+  "copy-doctor-command",
   "copy-npm-command",
   "developer-install",
+  "doctor-command",
   "eyebrow",
   "extension-update-section",
   "extension-version",
@@ -57,6 +61,9 @@ assert.equal(olderBridge.get("bridge-version").textContent, "v1.4.6");
 assert.equal(olderBridge.get("version-status").hidden, false);
 assert.equal(olderBridge.get("extension-update-section").hidden, true);
 assert.equal(olderBridge.get("npm-command").textContent, "npx --yes codex-firefox-bridge@1.4.7 install");
+assert.equal(olderBridge.get("doctor-command").textContent, "npx --yes codex-firefox-bridge@1.4.7 doctor");
+assert.equal(olderBridge.get("connection-explanation").hidden, true);
+assert.equal(olderBridge.get("chrome-prerequisite").hidden, true);
 assert.match(olderBridge.get("page-lede").textContent, /Update the bridge/u);
 
 const olderExtension = await render("?reason=version-mismatch&extensionVersion=1.4.7&bridgeVersion=1.4.8");

--- a/tests/test-firefox-compat.mjs
+++ b/tests/test-firefox-compat.mjs
@@ -315,8 +315,7 @@ assert.equal(sidePanelOpenEvents.length, 1, "Untrusted senders must not synthesi
 context.chrome.runtime.connectNative("com.openai.codexextension");
 nativePort.onDisconnect.emit();
 await new Promise((resolve) => setTimeout(resolve, 0));
-assert.equal(createdTabs.length, 1, "An immediate native disconnect must open companion setup.");
-assert.equal(createdTabs[0].url, "moz-extension://test/companion-required.html");
+assert.equal(createdTabs.length, 0, "An immediate native disconnect must keep setup inside the sidebar.");
 
 const events = [];
 compat.debugger.onEvent.addListener((sourceInfo, method, params) => events.push({ sourceInfo, method, params }));

--- a/tests/test-sidepanel-companion-setup.mjs
+++ b/tests/test-sidepanel-companion-setup.mjs
@@ -1,9 +1,15 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import {
+  CODEX_LOGO_PATH,
   getFirefoxCompanionSetupDetails,
   isFirefoxCompanionSetupError,
 } from "../extension/codex-sidepanel/firefox-companion-setup.js";
+
+assert.ok(
+  fs.existsSync(`extension/${CODEX_LOGO_PATH}`),
+  `The Codex logo referenced by the companion setup screen must exist: ${CODEX_LOGO_PATH}`,
+);
 
 assert.equal(isFirefoxCompanionSetupError("Native transport disconnected"), true);
 assert.equal(

--- a/tests/test-sidepanel-companion-setup.mjs
+++ b/tests/test-sidepanel-companion-setup.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import {
+  getFirefoxCompanionSetupDetails,
+  isFirefoxCompanionSetupError,
+} from "../extension/codex-sidepanel/firefox-companion-setup.js";
+
+assert.equal(isFirefoxCompanionSetupError("Native transport disconnected"), true);
+assert.equal(
+  isFirefoxCompanionSetupError("Startup failed: Native host request codexRuntime/hello timed out after 10s"),
+  true,
+);
+assert.equal(isFirefoxCompanionSetupError("A normal ChatGPT error"), false);
+
+const details = getFirefoxCompanionSetupDetails("1.2.3");
+assert.equal(details.command, "npx --yes codex-firefox-bridge@1.2.3 install");
+assert.equal(details.doctorCommand, "npx --yes codex-firefox-bridge@1.2.3 doctor");
+assert.match(details.chromeSetupUrl, /^https:\/\/learn\.chatgpt\.com\/docs\/chrome-extension/u);
+assert.match(details.windowsUrl, /v1\.2\.3\/codex-firefox-bridge-1\.2\.3-windows-x64-setup\.exe$/u);
+assert.match(details.macosUrl, /v1\.2\.3\/codex-firefox-bridge-1\.2\.3-macos-universal\.pkg$/u);
+
+const html = fs.readFileSync("extension/codex-sidepanel/index.html", "utf8");
+const bootstrap = fs.readFileSync("extension/codex-sidepanel/firefox-sidebar-bootstrap.js", "utf8");
+const css = fs.readFileSync("extension/codex-sidepanel/firefox-companion-setup.css", "utf8");
+assert.match(html, /href="\.\/firefox-companion-setup\.css"/u);
+assert.match(bootstrap, /installFirefoxCompanionSetup\(\{ extension \}\)/u);
+assert.ok(
+  bootstrap.indexOf("installFirefoxCompanionSetup") <
+    bootstrap.indexOf('await import("./assets/chrome-extension-sidepanel-Bf7FJEU3.js")'),
+  "Companion error observation must begin before the upstream sidebar loads.",
+);
+assert.match(css, /height: 100vh/u);
+assert.match(css, /overflow-y: auto/u);
+
+console.log(JSON.stringify({
+  ok: true,
+  embeddedSetup: true,
+  nativeErrorsDetected: true,
+  releaseLinksVersioned: true,
+  setupExplained: true,
+}, null, 2));


### PR DESCRIPTION
## What changed

- replace the inherited Chrome-only “open or update the desktop app” transport error with an embedded Firefox setup surface
- explain the complete local connection path:
  `Firefox extension → Firefox companion → OpenAI native host → ChatGPT/Codex`
- add the required **Plugins → Chrome** prerequisite and link to the [official OpenAI setup guide](https://learn.chatgpt.com/docs/chrome-extension#set-up-the-chrome-extension)
- provide matching Windows/macOS installers, version-pinned npm installation, and a copyable `doctor` command
- keep bridge-version mismatch guidance intact while avoiding a surprise setup tab for an initial native disconnect
- add responsive and regression coverage for the setup flow

## Why

Installing the Firefox bridge is only one half of the local connection. The bridge delegates to the separate `com.openai.codexextension` native host, which the ChatGPT/Codex desktop app registers through its official Chrome plugin setup.

The old sidebar interpreted an immediate disconnect as a generic Chrome transport failure and advised users only to reopen or update the desktop app. That hid the actionable setup path.

The new surface makes the dependency chain and recovery steps explicit:

1. Install Google Chrome temporarily if necessary.
2. In the ChatGPT or Codex desktop app, open **Plugins → Chrome** and complete setup.
3. Open Chrome once and confirm the ChatGPT side chat loads.
4. Install the matching Firefox companion.
5. Restart the desktop app and reopen the Firefox sidebar.
6. If it still fails, run `npx --yes codex-firefox-bridge@1.4.7 doctor` to check both local pieces.

Chrome does not need to become the user’s default browser or remain open, but the official Chrome integration/native host must remain installed.

## Screenshots

### Complete sidebar

<img src="https://codex-file-host.shawnadedeji.workers.dev/files/firefox-companion-setup-pr/c523ad8f9fb8-firefox-companion-setup-desktop.png" alt="Complete Firefox companion setup sidebar" width="520">

### Narrow responsive sidebar

<img src="https://codex-file-host.shawnadedeji.workers.dev/files/firefox-companion-setup-pr/ba88224b91a8-firefox-companion-setup-narrow.png" alt="Narrow responsive Firefox companion setup sidebar" width="360">

## Validation

- `npm test`
- `git diff --check origin/main`
- browser QA at 720px and narrow sidebar widths
- confirmed no horizontal overflow
- confirmed installers and the connection path stack vertically at narrow width


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added guided Firefox companion setup when native connection issues are detected.
  - Added platform-specific downloads, versioned installation commands, Chrome integration prerequisites, and diagnostic checks.
  - Added retry, troubleshooting, copy-command, and setup-guide actions.
  - Updated setup instructions to explain the two-part connection process and required restart steps.

- **Bug Fixes**
  - Prevented unexpected setup tabs from opening during transient connection failures.
  - Improved handling of older companion versions and clearer error-specific guidance.

- **Accessibility & Design**
  - Added responsive layouts, dark-mode support, keyboard focus states, and reduced-motion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->